### PR TITLE
feature/#17vector implimentation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,6 +9,7 @@ AlignArrayOfStructures: Right
 AlignOperands: Align
 AlignTrailingComments: false
 AllowShortBlocksOnASingleLine: Empty
+AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
@@ -34,8 +35,9 @@ BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: true
   AfterFunction: true
-  AfterStruct: true
+  AfterStruct: false
   AfterEnum: true
   BeforeElse: false
   BeforeWhile: false
+  SplitEmptyRecord: false
   SplitEmptyFunction: false

--- a/.clang-format
+++ b/.clang-format
@@ -18,7 +18,7 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakAfterDefinitionReturnType: false
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterComma
-ColumnLimit: 80
+ColumnLimit: 100
 ConstructorInitializerIndentWidth: 4
 FixNamespaceComments: true
 IncludeBlocks: Preserve

--- a/includes/algorithm.hpp
+++ b/includes/algorithm.hpp
@@ -7,7 +7,7 @@ template <class InputIt1, class InputIt2>
 bool equal(InputIt1 first1, InputIt1 last1, InputIt2 first2)
 {
 	for (; first1 != last1; ++first1, ++first2) {
-		if (first1 != first2)
+		if (*first1 != *first2)
 			return false;
 	}
 	return true;
@@ -27,9 +27,9 @@ template <class InputIt1, class InputIt2>
 bool lexicographical_compare(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2)
 {
 	for (; first2 != last2; ++first1, ++first2) {
-		if (first1 == last1 || first1 < first2)
+		if (first1 == last1 || *first1 < *first2)
 			return true;
-		if (first1 > first2)
+		if (*first1 > *first2)
 			return false;
 	}
 	return false;

--- a/includes/algorithm.hpp
+++ b/includes/algorithm.hpp
@@ -1,0 +1,53 @@
+#ifndef ALGORITHM_HPP
+#define ALGORITHM_HPP
+
+namespace ft {
+
+template <class InputIt1, class InputIt2>
+bool equal(InputIt1 first1, InputIt1 last1, InputIt2 first2)
+{
+	for (; first1 != last1; ++first1, ++first2) {
+		if (first1 != first2)
+			return false;
+	}
+	return true;
+}
+
+template <class InputIt1, class InputIt2, class BinaryPredicate>
+bool equal(InputIt1 first1, InputIt1 last1, InputIt2 first2, BinaryPredicate p)
+{
+	for (; first1 != last1; ++first1, ++first2) {
+		if (!p(*first1, *first2))
+			return false;
+	}
+	return true;
+}
+
+template <class InputIt1, class InputIt2>
+bool lexicographical_compare(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2)
+{
+	for (; first2 != last2; ++first1, ++first2) {
+		if (first1 == last1 || first1 < first2)
+			return true;
+		if (first1 > first2)
+			return false;
+	}
+	return false;
+}
+
+template <class InputIt1, class InputIt2, class Compare>
+bool lexicographical_compare(
+    InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, Compare comp)
+{
+	for (; first2 != last2; ++first1, ++first2) {
+		if (first1 == last1 || comp(*first1, *first2))
+			return true;
+		if (comp(*first2, *first1))
+			return false;
+	}
+	return false;
+}
+
+} // namespace ft
+
+#endif /* ALGORITHM_HPP */

--- a/includes/iterator_traits.hpp
+++ b/includes/iterator_traits.hpp
@@ -4,8 +4,7 @@
 namespace ft {
 
 template <class Iterator>
-struct iterator_traits
-{
+struct iterator_traits {
 	typedef typename Iterator::difference_type   difference_type;
 	typedef typename Iterator::value_type        value_type;
 	typedef typename Iterator::pointer           pointer;
@@ -14,8 +13,7 @@ struct iterator_traits
 };
 
 template <class T>
-struct iterator_traits<T*>
-{
+struct iterator_traits<T*> {
 	typedef ptrdiff_t                       difference_type;
 	typedef T                               value_type;
 	typedef T*                              pointer;
@@ -24,8 +22,7 @@ struct iterator_traits<T*>
 };
 
 template <class T>
-struct iterator_traits<const T*>
-{
+struct iterator_traits<const T*> {
 	typedef ptrdiff_t                       difference_type;
 	typedef T                               value_type;
 	typedef const T*                        pointer;

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -51,13 +51,13 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	}
 	random_access_iterator operator++(int)
 	{
-		random_access_iterator tmp(T);
+		random_access_iterator tmp(*this);
 		++__i;
 		return tmp;
 	}
 	random_access_iterator operator--(int)
 	{
-		random_access_iterator tmp(T);
+		random_access_iterator tmp(*this);
 		--__i;
 		return tmp;
 	}

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -67,7 +67,16 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		__i += rhs;
 		return *this;
 	}
-
+	friend random_access_iterator& operator-(int i, const random_access_iterator& rhs)
+	{
+		rhs.__i -= i;
+		return rhs;
+	}
+	random_access_iterator& operator-(difference_type rhs)
+	{
+		__i -= rhs;
+		return *this;
+	}
 	friend bool operator==(const random_access_iterator& lhs, const random_access_iterator& rhs)
 	{
 		return (lhs.__i == rhs.__i);
@@ -75,7 +84,16 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	friend bool operator<(const random_access_iterator& lhs, const random_access_iterator& rhs)
 	{
 		return (lhs.__i < rhs.__i);
-	};
+	}
+	friend random_access_iterator operator+(difference_type n, const random_access_iterator& it)
+	{
+		return (n + it.__i);
+	}
+	friend difference_type
+	operator-(const random_access_iterator& lhs, const random_access_iterator& rhs)
+	{
+		return (lhs.__i - rhs.__i);
+	}
 };
 
 template <class T>

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -7,8 +7,7 @@
 namespace ft {
 
 template <class T>
-class random_access_iterator
-    : public std::iterator<std::random_access_iterator_tag, T>
+class random_access_iterator : public std::iterator<std::random_access_iterator_tag, T>
 {
   public:
 	typedef typename iterator_traits<T*>::difference_type   difference_type;
@@ -24,8 +23,7 @@ class random_access_iterator
 	// (constructor)
 	random_access_iterator() : __i(NULL) {}
 	random_access_iterator(T* pointer) : __i(pointer) {}
-	random_access_iterator(random_access_iterator const& other) : __i(other.__i)
-	{}
+	random_access_iterator(random_access_iterator const& other) : __i(other.__i) {}
 	// (destructor)
 	~random_access_iterator() {}
 	random_access_iterator& operator=(random_access_iterator const& other)
@@ -59,8 +57,7 @@ class random_access_iterator
 		--__i;
 		return tmp;
 	}
-	friend random_access_iterator&
-	operator+(int i, const random_access_iterator& rhs)
+	friend random_access_iterator& operator+(int i, const random_access_iterator& rhs)
 	{
 		rhs.__i += i;
 		return rhs;
@@ -71,42 +68,35 @@ class random_access_iterator
 		return *this;
 	}
 
-	friend bool operator==(
-	    const random_access_iterator& lhs, const random_access_iterator& rhs)
+	friend bool operator==(const random_access_iterator& lhs, const random_access_iterator& rhs)
 	{
 		return (lhs.__i == rhs.__i);
 	}
-	friend bool operator<(
-	    const random_access_iterator& lhs, const random_access_iterator& rhs);
+	friend bool operator<(const random_access_iterator& lhs, const random_access_iterator& rhs);
 };
 
 template <class T>
-bool operator!=(
-    const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+bool operator!=(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
 {
 	return (!(lhs == rhs));
 }
 template <class T>
-bool operator<(
-    const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+bool operator<(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
 {
 	return (lhs.__i < rhs.__i);
 }
 template <class T>
-bool operator<=(
-    const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+bool operator<=(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
 {
 	return (lhs < rhs || lhs == rhs);
 }
 template <class T>
-bool operator>(
-    const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+bool operator>(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
 {
 	return (!(lhs < rhs) && !(lhs == rhs));
 }
 template <class T>
-bool operator>=(
-    const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+bool operator>=(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
 {
 	return !(lhs < rhs);
 }

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -85,19 +85,10 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	}
 	/* 	the rest implemented outside of this class */
 
-	friend random_access_iterator& operator+(int i, const random_access_iterator& rhs)
-	{
-		rhs.__i += i;
-		return rhs;
-	}
-	friend random_access_iterator& operator-(int i, const random_access_iterator& rhs)
-	{
-		rhs.__i -= i;
-		return rhs;
-	}
 	friend random_access_iterator operator+(difference_type n, const random_access_iterator& it)
 	{
-		return (n + it.__i);
+		it.__i += n;
+		return it;
 	}
 	friend difference_type
 	operator-(const random_access_iterator& lhs, const random_access_iterator& rhs)

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -72,7 +72,10 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	{
 		return (lhs.__i == rhs.__i);
 	}
-	friend bool operator<(const random_access_iterator& lhs, const random_access_iterator& rhs);
+	friend bool operator<(const random_access_iterator& lhs, const random_access_iterator& rhs)
+	{
+		return (lhs.__i < rhs.__i);
+	};
 };
 
 template <class T>

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -26,6 +26,7 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	random_access_iterator(random_access_iterator const& other) : __i(other.__i) {}
 	// (destructor)
 	~random_access_iterator() {}
+
 	random_access_iterator& operator=(random_access_iterator const& other)
 	{
 		__i = other.__i;
@@ -35,9 +36,17 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	reference operator*() { return *__i; }
 	pointer   operator->() { return __i; }
 
+	// operator[]
+
+	/* ------------------------- Advances / Decrements ------------------------- */
 	random_access_iterator& operator++()
 	{
 		++__i;
+		return *this;
+	}
+	random_access_iterator& operator--()
+	{
+		--__i;
 		return *this;
 	}
 	random_access_iterator operator++(int)
@@ -46,37 +55,26 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		++__i;
 		return tmp;
 	}
-	random_access_iterator& operator--()
-	{
-		--__i;
-		return *this;
-	}
 	random_access_iterator operator--(int)
 	{
 		random_access_iterator tmp(T);
 		--__i;
 		return tmp;
 	}
-	friend random_access_iterator& operator+(int i, const random_access_iterator& rhs)
-	{
-		rhs.__i += i;
-		return rhs;
-	}
 	random_access_iterator& operator+(difference_type rhs)
 	{
 		__i += rhs;
 		return *this;
-	}
-	friend random_access_iterator& operator-(int i, const random_access_iterator& rhs)
-	{
-		rhs.__i -= i;
-		return rhs;
 	}
 	random_access_iterator& operator-(difference_type rhs)
 	{
 		__i -= rhs;
 		return *this;
 	}
+	// operator+=
+	// operator-=
+
+	/* -------------------------- Non-member functions ------------------------- */
 	friend bool operator==(const random_access_iterator& lhs, const random_access_iterator& rhs)
 	{
 		return (lhs.__i == rhs.__i);
@@ -84,6 +82,18 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	friend bool operator<(const random_access_iterator& lhs, const random_access_iterator& rhs)
 	{
 		return (lhs.__i < rhs.__i);
+	}
+	/* 	the rest implemented outside of this class */
+
+	friend random_access_iterator& operator+(int i, const random_access_iterator& rhs)
+	{
+		rhs.__i += i;
+		return rhs;
+	}
+	friend random_access_iterator& operator-(int i, const random_access_iterator& rhs)
+	{
+		rhs.__i -= i;
+		return rhs;
 	}
 	friend random_access_iterator operator+(difference_type n, const random_access_iterator& it)
 	{

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -21,8 +21,8 @@ class reverse_iterator
 
   public:
 	// (constructor)
-	reverse_iterator();
-	explicit reverse_iterator(iterator_type x);
+	reverse_iterator(){};
+	explicit reverse_iterator(iterator_type x){};
 	template <class U>
 	reverse_iterator(const reverse_iterator<U>& other){};
 	// operator=

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -17,71 +17,71 @@ class reverse_iterator
 	typedef typename iterator_traits<Iter>::reference         reference;
 
   protected:
-	Iter _current;
+	Iter current;
 
   public:
 	// (constructor)
 	reverse_iterator(){};
-	explicit reverse_iterator(iterator_type x) : _current(x){};
+	explicit reverse_iterator(iterator_type x) : current(x){};
 	template <class U>
-	reverse_iterator(const reverse_iterator<U>& other) : _current(other._current){};
+	reverse_iterator(const reverse_iterator<U>& other) : current(other.current){};
 	// operator=
 	template <class U>
 	reverse_iterator& operator=(const reverse_iterator<U>& other)
 	{
-		_current = other._current;
+		current = other.current;
 		return *this;
 	};
-	iterator_type base() const { return _current; };
+	iterator_type base() const { return current; };
 	reference     operator*() const
 	{
-		Iter tmp = _current;
+		Iter tmp = current;
 		return *--tmp;
 	};
-	pointer operator->() const { return &--_current; };
+	pointer operator->() const { return &--current; };
 	// /*unspecified*/   operator[](difference_type n) const;
 	reverse_iterator& operator++()
 	{
-		++_current;
+		++current;
 		return *this;
 	};
 	reverse_iterator& operator--()
 	{
-		--_current;
+		--current;
 		return *this;
 	};
 	reverse_iterator operator++(int)
 	{
 		reverse_iterator tmp(*this);
-		++_current;
+		++current;
 		return tmp;
 	};
 	reverse_iterator operator--(int)
 	{
 		reverse_iterator tmp(*this);
-		--_current;
+		--current;
 		return tmp;
 	};
 	reverse_iterator operator+(difference_type n) const
 	{
-		Iter tmp = _current;
+		Iter tmp = current;
 		tmp += n;
 		return tmp;
 	};
 	reverse_iterator operator-(difference_type n) const
 	{
-		Iter tmp = _current;
+		Iter tmp = current;
 		tmp -= n;
 		return tmp;
 	};
 	reverse_iterator& operator+=(difference_type n)
 	{
-		_current += n;
+		current += n;
 		return *this;
 	};
 	reverse_iterator& operator-=(difference_type n)
 	{
-		_current -= n;
+		current -= n;
 		return *this;
 	};
 

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -21,69 +21,70 @@ class reverse_iterator
 
   public:
 	// (constructor)
-	reverse_iterator(){};
-	explicit reverse_iterator(iterator_type x) : current(x){};
+	reverse_iterator() {}
+	explicit reverse_iterator(iterator_type x) : current(x) {}
 	template <class U>
-	reverse_iterator(const reverse_iterator<U>& other) : current(other.current){};
+	reverse_iterator(const reverse_iterator<U>& other) : current(other.current)
+	{}
 	// operator=
 	template <class U>
 	reverse_iterator& operator=(const reverse_iterator<U>& other)
 	{
 		current = other.current;
 		return *this;
-	};
-	iterator_type base() const { return current; };
+	}
+	iterator_type base() const { return current; }
 	reference     operator*() const
 	{
 		Iter tmp = current;
 		return *--tmp;
-	};
-	pointer operator->() const { return &--current; };
+	}
+	pointer operator->() const { return &--current; }
 	// /*unspecified*/   operator[](difference_type n) const;
 	reverse_iterator& operator++()
 	{
 		++current;
 		return *this;
-	};
+	}
 	reverse_iterator& operator--()
 	{
 		--current;
 		return *this;
-	};
+	}
 	reverse_iterator operator++(int)
 	{
 		reverse_iterator tmp(*this);
 		++current;
 		return tmp;
-	};
+	}
 	reverse_iterator operator--(int)
 	{
 		reverse_iterator tmp(*this);
 		--current;
 		return tmp;
-	};
+	}
 	reverse_iterator operator+(difference_type n) const
 	{
 		Iter tmp = current;
 		tmp += n;
 		return tmp;
-	};
+	}
 	reverse_iterator operator-(difference_type n) const
 	{
 		Iter tmp = current;
 		tmp -= n;
 		return tmp;
-	};
+	}
 	reverse_iterator& operator+=(difference_type n)
 	{
 		current += n;
 		return *this;
-	};
+	}
 	reverse_iterator& operator-=(difference_type n)
 	{
 		current -= n;
 		return *this;
-	};
+	}
 
 	/* ------------------------ Non-member functions ------------------------ */
 	template <class Iterator1, class Iterator2>

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -21,7 +21,7 @@ class reverse_iterator
 
   public:
 	// (constructor)
-	reverse_iterator() {}
+	reverse_iterator() : current(Iter()) {}
 	explicit reverse_iterator(iterator_type x) : current(x) {}
 	template <class U>
 	reverse_iterator(const reverse_iterator<U>& other) : current(other.current)
@@ -39,7 +39,11 @@ class reverse_iterator
 		Iter tmp = current;
 		return *--tmp;
 	}
-	pointer operator->() const { return &--current; }
+	pointer operator->() const
+	{
+		Iter tmp = current;
+		return &--tmp;
+	}
 	// /*unspecified*/   operator[](difference_type n) const;
 	reverse_iterator& operator++()
 	{

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -47,46 +47,46 @@ class reverse_iterator
 	// /*unspecified*/   operator[](difference_type n) const;
 	reverse_iterator& operator++()
 	{
-		++current;
+		--current;
 		return *this;
 	}
 	reverse_iterator& operator--()
 	{
-		--current;
+		++current;
 		return *this;
 	}
 	reverse_iterator operator++(int)
 	{
 		reverse_iterator tmp(*this);
-		++current;
+		--current;
 		return tmp;
 	}
 	reverse_iterator operator--(int)
 	{
 		reverse_iterator tmp(*this);
-		--current;
+		++current;
 		return tmp;
 	}
 	reverse_iterator operator+(difference_type n) const
 	{
 		Iter tmp = current;
-		tmp += n;
+		tmp -= n;
 		return tmp;
 	}
 	reverse_iterator operator-(difference_type n) const
 	{
 		Iter tmp = current;
-		tmp -= n;
+		tmp += n;
 		return tmp;
 	}
 	reverse_iterator& operator+=(difference_type n)
 	{
-		current += n;
+		current -= n;
 		return *this;
 	}
 	reverse_iterator& operator-=(difference_type n)
 	{
-		current -= n;
+		current += n;
 		return *this;
 	}
 
@@ -129,15 +129,15 @@ class reverse_iterator
 	}
 };
 
-template <class Iter>
-reverse_iterator<Iter>
-operator+(typename reverse_iterator<Iter>::difference_type n, const reverse_iterator<Iter>& it)
-{}
+// template <class Iter>
+// reverse_iterator<Iter>
+// operator+(typename reverse_iterator<Iter>::difference_type n, const reverse_iterator<Iter>& it)
+// {}
 
-template <class Iterator>
-typename reverse_iterator<Iterator>::difference_type
-operator-(const reverse_iterator<Iterator>& lhs, const reverse_iterator<Iterator>& rhs)
-{}
+// template <class Iterator>
+// typename reverse_iterator<Iterator>::difference_type
+// operator-(const reverse_iterator<Iterator>& lhs, const reverse_iterator<Iterator>& rhs)
+// {}
 } // namespace ft
 
 #endif /* REVERSE_ITERATOR_HPP */

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -16,56 +16,112 @@ class reverse_iterator
 	typedef typename iterator_traits<Iter>::pointer           pointer;
 	typedef typename iterator_traits<Iter>::reference         reference;
 
-  private:
+  protected:
 	Iter _current;
 
   public:
 	// (constructor)
 	reverse_iterator(){};
-	explicit reverse_iterator(iterator_type x){};
+	explicit reverse_iterator(iterator_type x) : _current(x){};
 	template <class U>
-	reverse_iterator(const reverse_iterator<U>& other){};
+	reverse_iterator(const reverse_iterator<U>& other) : _current(other._current){};
 	// operator=
 	template <class U>
-	reverse_iterator& operator=(const reverse_iterator<U>& other){};
-	iterator_type     base() const {};
-	reference         operator*() const {};
-	pointer           operator->() const {};
+	reverse_iterator& operator=(const reverse_iterator<U>& other)
+	{
+		_current = other._current;
+		return *this;
+	};
+	iterator_type base() const { return _current; };
+	reference     operator*() const
+	{
+		Iter tmp = _current;
+		return *--tmp;
+	};
+	pointer operator->() const { return &--_current; };
 	// /*unspecified*/   operator[](difference_type n) const;
-	reverse_iterator& operator++(){};
-	reverse_iterator& operator--(){};
-	reverse_iterator  operator++(int){};
-	reverse_iterator  operator--(int){};
-	reverse_iterator  operator+(difference_type n) const {};
-	reverse_iterator  operator-(difference_type n) const {};
-	reverse_iterator& operator+=(difference_type n){};
-	reverse_iterator& operator-=(difference_type n){};
+	reverse_iterator& operator++()
+	{
+		++_current;
+		return *this;
+	};
+	reverse_iterator& operator--()
+	{
+		--_current;
+		return *this;
+	};
+	reverse_iterator operator++(int)
+	{
+		reverse_iterator tmp(*this);
+		++_current;
+		return tmp;
+	};
+	reverse_iterator operator--(int)
+	{
+		reverse_iterator tmp(*this);
+		--_current;
+		return tmp;
+	};
+	reverse_iterator operator+(difference_type n) const
+	{
+		Iter tmp = _current;
+		tmp += n;
+		return tmp;
+	};
+	reverse_iterator operator-(difference_type n) const
+	{
+		Iter tmp = _current;
+		tmp -= n;
+		return tmp;
+	};
+	reverse_iterator& operator+=(difference_type n)
+	{
+		_current += n;
+		return *this;
+	};
+	reverse_iterator& operator-=(difference_type n)
+	{
+		_current -= n;
+		return *this;
+	};
 
 	/* ------------------------ Non-member functions ------------------------ */
 	template <class Iterator1, class Iterator2>
 	friend bool operator==(
 	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
-	{}
+	{
+		return (lhs.base() == rhs.base());
+	}
 	template <class Iterator1, class Iterator2>
 	friend bool operator!=(
 	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
-	{}
+	{
+		return (lhs.base() != rhs.base());
+	}
 	template <class Iterator1, class Iterator2>
 	friend bool operator<(
 	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
-	{}
+	{
+		return (lhs.base() < rhs.base());
+	}
 	template <class Iterator1, class Iterator2>
 	friend bool operator<=(
 	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
-	{}
+	{
+		return (lhs.base() <= rhs.base());
+	}
 	template <class Iterator1, class Iterator2>
 	friend bool operator>(
 	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
-	{}
+	{
+		return (lhs.base() > rhs.base());
+	}
 	template <class Iterator1, class Iterator2>
 	friend bool operator>=(
 	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
-	{}
+	{
+		return (lhs.base() >= rhs.base());
+	}
 };
 
 template <class Iter>

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -43,41 +43,39 @@ class reverse_iterator
 
 	/* ------------------------ Non-member functions ------------------------ */
 	template <class Iterator1, class Iterator2>
-	friend bool operator==(const std::reverse_iterator<Iterator1>& lhs,
-	    const std::reverse_iterator<Iterator2>&                    rhs)
+	friend bool operator==(
+	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
 	{}
 	template <class Iterator1, class Iterator2>
-	friend bool operator!=(const std::reverse_iterator<Iterator1>& lhs,
-	    const std::reverse_iterator<Iterator2>&                    rhs)
+	friend bool operator!=(
+	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
 	{}
 	template <class Iterator1, class Iterator2>
-	friend bool operator<(const std::reverse_iterator<Iterator1>& lhs,
-	    const std::reverse_iterator<Iterator2>&                   rhs)
+	friend bool operator<(
+	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
 	{}
 	template <class Iterator1, class Iterator2>
-	friend bool operator<=(const std::reverse_iterator<Iterator1>& lhs,
-	    const std::reverse_iterator<Iterator2>&                    rhs)
+	friend bool operator<=(
+	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
 	{}
 	template <class Iterator1, class Iterator2>
-	friend bool operator>(const std::reverse_iterator<Iterator1>& lhs,
-	    const std::reverse_iterator<Iterator2>&                   rhs)
+	friend bool operator>(
+	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
 	{}
 	template <class Iterator1, class Iterator2>
-	friend bool operator>=(const std::reverse_iterator<Iterator1>& lhs,
-	    const std::reverse_iterator<Iterator2>&                    rhs)
+	friend bool operator>=(
+	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
 	{}
 };
 
 template <class Iter>
 reverse_iterator<Iter>
-operator+(typename reverse_iterator<Iter>::difference_type n,
-    const reverse_iterator<Iter>&                          it)
+operator+(typename reverse_iterator<Iter>::difference_type n, const reverse_iterator<Iter>& it)
 {}
 
 template <class Iterator>
 typename reverse_iterator<Iterator>::difference_type
-operator-(const reverse_iterator<Iterator>& lhs,
-    const reverse_iterator<Iterator>&       rhs)
+operator-(const reverse_iterator<Iterator>& lhs, const reverse_iterator<Iterator>& rhs)
 {}
 } // namespace ft
 

--- a/includes/type_traits.hpp
+++ b/includes/type_traits.hpp
@@ -1,0 +1,13 @@
+#ifndef TYPE_TRAITS_HPP
+#define TYPE_TRAITS_HPP
+
+namespace ft {
+
+template <bool B, class T = void>
+struct enable_if
+{
+};
+
+} // namespace ft
+
+#endif /* TYPE_TRAITS_HPP */

--- a/includes/type_traits.hpp
+++ b/includes/type_traits.hpp
@@ -4,9 +4,8 @@
 namespace ft {
 
 template <bool B, class T = void>
-struct enable_if
-{
-};
+struct enable_if {};
+
 
 } // namespace ft
 

--- a/includes/type_traits.hpp
+++ b/includes/type_traits.hpp
@@ -14,7 +14,51 @@ struct enable_if {
 template <class T>
 struct enable_if<false, T> {};
 
+/* -------------------------------------------------------------------------- */
+/*                                 is_integral                                */
+/* -------------------------------------------------------------------------- */
 
+/* ---------------------------- integral_constant --------------------------- */
+template <class T, T v>
+struct integral_constant {
+	static const T value = v;
+
+	typedef T                 value_type;
+	typedef integral_constant type;
+
+	operator value_type() const { return value; }
+};
+
+/* -------------------------- true_type, false_type ------------------------- */
+typedef integral_constant<bool, true>  true_type;
+typedef integral_constant<bool, false> false_type;
+
+/* ------------------------- __libcppft_is_integral ------------------------- */
+/* bool, char, char16_t, char32_t, wchar_t, short, int, long, long long */
+template <class T>
+struct __libcppft_is_integral : public false_type {};
+template <>
+struct __libcppft_is_integral<bool> : public true_type {};
+template <>
+struct __libcppft_is_integral<char> : public true_type {};
+template <>
+struct __libcppft_is_integral<char16_t> : public true_type {};
+template <>
+struct __libcppft_is_integral<char32_t> : public true_type {};
+template <>
+struct __libcppft_is_integral<wchar_t> : public true_type {};
+template <>
+struct __libcppft_is_integral<short> : public true_type {};
+template <>
+struct __libcppft_is_integral<int> : public true_type {};
+template <>
+struct __libcppft_is_integral<long> : public true_type {};
+template <>
+struct __libcppft_is_integral<unsigned long> : public true_type {};
+
+/* ------------------------------- is_integral ------------------------------ */
+template <class T>
+struct is_integral : public __libcppft_is_integral<typename std::remove_cv<T>::type> {};
 
 } // namespace ft
 

--- a/includes/type_traits.hpp
+++ b/includes/type_traits.hpp
@@ -3,8 +3,17 @@
 
 namespace ft {
 
+/* -------------------------------------------------------------------------- */
+/*                                  enable_if                                 */
+/* -------------------------------------------------------------------------- */
 template <bool B, class T = void>
-struct enable_if {};
+struct enable_if {
+	typedef T type;
+};
+
+template <class T>
+struct enable_if<false, T> {};
+
 
 
 } // namespace ft

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -97,7 +97,7 @@ class vector
 	void push_back(const T& value);
 	// pop_back
 	void pop_back() { _destruct_at_end(1); }
-	void resize(size_type count, T value = T()) {}
+	void resize(size_type count, T value = T());
 	void swap(vector& other);
 
   private:
@@ -323,6 +323,25 @@ void vector<T, Allocator>::push_back(const T& value)
 		reserve(new_size);
 	_construct_at_end(1);
 	*(_end - 1) = value;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   resize                                   */
+/* -------------------------------------------------------------------------- */
+template <class T, class Allocator>
+void vector<T, Allocator>::resize(size_type count, T value)
+{
+	size_type diff;
+
+	if (size() > count) {
+		diff = size() - count;
+		_destruct_at_end(diff);
+	} else if (size() < count) {
+		diff = count - size();
+		if (capacity() < count)
+			reserve(count);
+		_construct_at_end(diff, value);
+	}
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -28,10 +28,11 @@ class vector
   private:
 	pointer        _begin;
 	pointer        _end;
+	pointer        _end_cap;
 	allocator_type _alloc;
 
   public:
-	vector(){};
+	vector() : _begin(NULL), _end(NULL), _end_cap(NULL), _alloc(Allocator()){};
 	explicit vector(const Allocator& alloc);
 	explicit vector(size_type count, const T& value = T(),
 	    const Allocator& alloc = Allocator());
@@ -100,19 +101,25 @@ class vector
 /*                                 constructor                                */
 /* -------------------------------------------------------------------------- */
 template <class T, class Allocator>
-vector<T, Allocator>::vector(const Allocator& alloc) : _alloc(alloc)
+vector<T, Allocator>::vector(const Allocator& alloc) :
+    _begin(NULL), _end(NULL), _end_cap(NULL), _alloc(alloc)
 {}
 
 template <class T, class Allocator>
 vector<T, Allocator>::vector(
     size_type count, const T& value, const Allocator& alloc) :
-    _alloc(alloc)
-{}
+    _begin(NULL),
+    _end(NULL), _end_cap(NULL), _alloc(alloc)
+{
+	assign(count, value);
+}
+
 template <class T, class Allocator>
 template <class InputIt>
 vector<T, Allocator>::vector(
     InputIt first, InputIt last, const Allocator& alloc) :
-    _alloc(alloc)
+    _begin(NULL),
+    _end(NULL), _end_cap(NULL), _alloc(alloc)
 {}
 template <class T, class Allocator>
 vector<T, Allocator>::vector(const vector& other) : _alloc(other._alloc)

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -391,7 +391,7 @@ bool operator<=(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
 template <class T, class Alloc>
 bool operator>(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
 {
-	return !(lhs < rhs);
+	return !(lhs <= rhs);
 }
 
 template <class T, class Alloc>

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -93,7 +93,8 @@ class vector
 	iterator erase(iterator first, iterator last){};
 	// push_back
 	void push_back(const T& value);
-	void pop_back();
+	// pop_back
+	void pop_back() { _destruct_at_end(_end - 1); };
 	void resize(size_type count, T value = T()){};
 	void swap(vector& other){};
 
@@ -253,15 +254,6 @@ void vector<T, Allocator>::push_back(const T& value)
 		reserve(new_size);
 	_construct_at_end(1);
 	*(_end - 1) = value;
-}
-
-/* -------------------------------------------------------------------------- */
-/*                                  pop_back                                  */
-/* -------------------------------------------------------------------------- */
-template <class T, class Allocator>
-void vector<T, Allocator>::pop_back()
-{
-	_destruct_at_end(_end - 1);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -78,7 +78,7 @@ class vector
 	bool      empty() const {};
 	size_type size() const {};
 	size_type max_size() const {};
-	void      reserve(size_type new_cap){};
+	void      reserve(size_type new_cap);
 	size_type capacity() const {};
 	/* ------------------------------ Modifiers ----------------------------- */
 	void clear(){};
@@ -156,6 +156,24 @@ template <class T, class Allocator>
 typename vector<T, Allocator>::const_reference
 vector<T, Allocator>::at(size_type pos) const
 {}
+
+/* -------------------------------------------------------------------------- */
+/*                                   reserve                                  */
+/* -------------------------------------------------------------------------- */
+template <class T, class Allocator>
+void vector<T, Allocator>::reserve(size_type new_cap)
+{
+	if (capacity() > new_cap)
+		return;
+	size_type _size     = size();
+	pointer   new_begin = _alloc.allocate(new_cap);
+	std::uninitialized_copy(_begin, _end, new_begin);
+	_alloc.destroy(_begin);
+
+	_begin   = new_begin;
+	_end     = _begin + _size;
+	_end_cap = _begin + new_cap;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                   insert                                   */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -91,8 +91,8 @@ class vector
 	void insert(iterator pos, InputIt first, InputIt last,
 	    typename ft::enable_if<!ft::is_integral<InputIt>::value>::type* = 0);
 	// erase
-	iterator erase(iterator pos){};
-	iterator erase(iterator first, iterator last){};
+	iterator erase(iterator pos);
+	iterator erase(iterator first, iterator last);
 	// push_back
 	void push_back(const T& value);
 	// pop_back
@@ -287,6 +287,28 @@ void vector<T, Allocator>::insert(iterator pos, InputIt first, InputIt last,
 	for (InputIt it = first; it != last; ++it, ++pos) {
 		*pos = *it;
 	}
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                    erase                                   */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Allocator>
+typename vector<T, Allocator>::iterator vector<T, Allocator>::erase(iterator pos)
+{
+	std::copy(pos + 1, end(), pos);
+	_destruct_at_end(1);
+	return pos;
+}
+
+template <class T, class Allocator>
+typename vector<T, Allocator>::iterator vector<T, Allocator>::erase(iterator first, iterator last)
+{
+	size_type count = last - first;
+
+	std::copy(last, end(), first);
+	_destruct_at_end(count);
+	return first;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -96,13 +96,14 @@ class vector
 	// push_back
 	void push_back(const T& value);
 	// pop_back
-	void pop_back() { _destruct_at_end(_end - 1); };
+	void pop_back() { _destruct_at_end(1); };
 	void resize(size_type count, T value = T()){};
 	void swap(vector& other);
 
   private:
 	void _vallocate(size_type n);
 	void _construct_at_end(size_type n);
+	void _destruct_at_end(size_type n);
 	void _destruct_at_end(pointer new_last);
 };
 
@@ -394,6 +395,16 @@ void vector<T, Alloc>::_construct_at_end(size_type n)
 	while (n > 0) {
 		_alloc.construct(_end);
 		++_end;
+		--n;
+	}
+}
+
+template <class T, class Alloc>
+void vector<T, Alloc>::_destruct_at_end(size_type n)
+{
+	while (n > 0) {
+		--_end;
+		_alloc.destroy(_end);
 		--n;
 	}
 }

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -1,6 +1,7 @@
 #ifndef VECTOR_HPP
 #define VECTOR_HPP
 
+#include "algorithm.hpp"
 #include "iterators.hpp"
 #include <iostream>
 #include <memory>
@@ -272,26 +273,39 @@ void vector<T, Allocator>::push_back(const T& value)
 
 template <class T, class Alloc>
 bool operator==(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
-{}
+{
+	return (lhs.size() == rhs.size() && ft::equal(lhs.begin(), lhs.end(), rhs.begin()));
+}
+
 template <class T, class Alloc>
 bool operator!=(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
-{}
+{
+	return !(lhs == rhs);
+}
 
 template <class T, class Alloc>
 bool operator<(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
-{}
+{
+	return (ft::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end()));
+}
 
 template <class T, class Alloc>
 bool operator<=(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
-{}
+{
+	return (lhs == rhs || lhs < rhs);
+}
 
 template <class T, class Alloc>
 bool operator>(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
-{}
+{
+	return !(lhs < rhs);
+}
 
 template <class T, class Alloc>
 bool operator>=(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
-{}
+{
+	return (lhs == rhs || lhs > rhs);
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                  std::swap                                 */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -96,7 +96,7 @@ class vector
 	// pop_back
 	void pop_back() { _destruct_at_end(_end - 1); };
 	void resize(size_type count, T value = T()){};
-	void swap(vector& other){};
+	void swap(vector& other);
 
   private:
 	void _vallocate(size_type n);
@@ -257,6 +257,22 @@ void vector<T, Allocator>::push_back(const T& value)
 }
 
 /* -------------------------------------------------------------------------- */
+/*                                    swap                                    */
+/* -------------------------------------------------------------------------- */
+template <class T, class Allocator>
+void vector<T, Allocator>::swap(vector& other)
+{
+	vector<T, Allocator> save = *this;
+
+	_begin         = other._begin;
+	_end           = other._end;
+	_end_cap       = other._end_cap;
+	other._begin   = save._begin;
+	other._end     = save._end;
+	other._end_cap = save._end_cap;
+}
+
+/* -------------------------------------------------------------------------- */
 /*                            Non-member functions                            */
 /* -------------------------------------------------------------------------- */
 
@@ -302,7 +318,16 @@ bool operator>=(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
 
 template <class T, class Alloc>
 void swap(std::vector<T, Alloc>& lhs, std::vector<T, Alloc>& rhs)
-{}
+{
+	std::vector<T, Alloc> save = lhs;
+
+	lhs._begin   = rhs._begin;
+	lhs._end     = rhs._end;
+	lhs._end_cap = rhs._end_cap;
+	rhs._begin   = save._begin;
+	rhs._end     = save._end;
+	rhs._end_cap = save._end_cap;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                          private member functions                          */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -141,7 +141,15 @@ vector<T, Allocator>::vector(const vector& other) : _alloc(other._alloc)
 /* -------------------------------------------------------------------------- */
 template <class T, class Allocator>
 vector<T, Allocator>& vector<T, Allocator>::operator=(const vector<T, Allocator>& other)
-{}
+{
+	if (this != &other) {
+		size_type count = other.size();
+		_vallocate(count);
+		std::uninitialized_copy(other._begin, other._end, _begin);
+		_end = _begin + count;
+	}
+	return *this;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                   assign                                   */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -75,7 +75,7 @@ class vector
 	reverse_iterator       rend(){};
 	const_reverse_iterator rend() const {};
 	// ------------------------------ Capacity ------------------------------ //
-	bool      empty() const {};
+	bool      empty() const { return (size() == 0); };
 	size_type size() const { return static_cast<size_type>(_end - _begin); };
 	size_type max_size() const { return std::numeric_limits<difference_type>::max(); };
 	void      reserve(size_type new_cap);

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -93,7 +93,7 @@ class vector
 	iterator erase(iterator first, iterator last){};
 	// push_back
 	void push_back(const T& value);
-	void pop_back(){};
+	void pop_back();
 	void resize(size_type count, T value = T()){};
 	void swap(vector& other){};
 
@@ -265,6 +265,15 @@ void vector<T, Allocator>::push_back(const T& value)
 		reserve(new_size);
 	_begin[new_size - 1] = value;
 	_end++;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  pop_back                                  */
+/* -------------------------------------------------------------------------- */
+template <class T, class Allocator>
+void vector<T, Allocator>::pop_back()
+{
+	_destruct_at_end(_end - 1);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -63,8 +63,8 @@ class vector
 	reference       back(){};
 	const_reference back() const {};
 	// data
-	T*       data(){};
-	const T* data() const {};
+	T*       data() { return static_cast<T*>(_begin); };
+	const T* data() const { return static_cast<const T*>(_begin); };
 	// ------------------------------ Iterators ----------------------------- //
 	iterator               begin(){};
 	const_iterator         begin() const {};

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -79,7 +79,8 @@ class vector
 	// ------------------------------ Capacity ------------------------------ //
 	bool      empty() const { return (size() == 0); }
 	size_type size() const { return static_cast<size_type>(_end - _begin); }
-	size_type max_size() const { return std::numeric_limits<difference_type>::max(); }
+	// max_size
+	size_type max_size() const;
 	void      reserve(size_type new_cap);
 	size_type capacity() const { return static_cast<size_type>(_end_cap - _begin); }
 	/* ------------------------------ Modifiers ----------------------------- */
@@ -230,6 +231,15 @@ void vector<T, Allocator>::reserve(size_type new_cap)
 	_begin   = new_begin;
 	_end     = _begin + _size;
 	_end_cap = _begin + new_cap;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  max_size                                  */
+/* -------------------------------------------------------------------------- */
+template <class T, class Allocator>
+typename vector<T, Allocator>::size_type vector<T, Allocator>::max_size() const
+{
+	return std::min<size_type>(std::numeric_limits<difference_type>::max(), _alloc.max_size());
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -228,20 +228,59 @@ void vector<T, Allocator>::reserve(size_type new_cap)
 /* -------------------------------------------------------------------------- */
 /*                                   insert                                   */
 /* -------------------------------------------------------------------------- */
-// /*
 template <class T, class Allocator>
 typename vector<T, Allocator>::iterator vector<T, Allocator>::insert(iterator pos, const T& value)
-{}
+{
+	difference_type offset = pos - begin();
+
+	if (size() + 1 > capacity()) {
+		reserve(size() + 1);
+	}
+	pointer insert_p = _begin + offset;
+	_construct_at_end(1);
+	std::copy_backward(insert_p, _end - 1, _end);
+
+	*insert_p = value;
+	return iterator(insert_p);
+}
 
 template <class T, class Allocator>
 void vector<T, Allocator>::insert(iterator pos, size_type count, const T& value)
-{}
+{
+	difference_type offset = pos - begin();
+
+	if (size() + count > capacity()) {
+		reserve(size() + count);
+	}
+
+	pointer insert_p = _begin + offset;
+	_construct_at_end(count);
+	std::copy_backward(insert_p, _end - count, _end);
+
+	for (size_type i = 0; i < count; ++i) {
+		insert_p[i] = value;
+	}
+}
 
 template <class T, class Allocator>
 template <class InputIt>
 void vector<T, Allocator>::insert(iterator pos, InputIt first, InputIt last)
-{}
-// */
+{
+	difference_type count  = last - first;
+	difference_type offset = pos - begin();
+
+	if (size() + count >= capacity()) {
+		reserve(size() + count);
+	}
+
+	pos = _begin + offset;
+	_construct_at_end(count);
+	std::copy_backward(pos, end() - count, end());
+
+	for (InputIt it = first; it != last; ++it, ++pos) {
+		*pos = *it;
+	}
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                  push_back                                 */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -118,9 +118,9 @@ vector<T, Allocator>::vector(const Allocator& alloc) :
 template <class T, class Allocator>
 vector<T, Allocator>::vector(
     size_type count, const T& value, const Allocator& alloc) :
-    _begin(NULL),
-    _end(NULL), _end_cap(NULL), _alloc(alloc)
+    _alloc(alloc)
 {
+	_vallocate(count);
 	assign(count, value);
 }
 
@@ -128,12 +128,23 @@ template <class T, class Allocator>
 template <class InputIt>
 vector<T, Allocator>::vector(
     InputIt first, InputIt last, const Allocator& alloc) :
-    _begin(NULL),
-    _end(NULL), _end_cap(NULL), _alloc(alloc)
-{}
+    _alloc(alloc)
+{
+	size_type count = static_cast<size_type>(last - first);
+	_vallocate(count);
+	std::uninitialized_copy(first, last, _begin);
+	_end = _begin + count;
+}
+
 template <class T, class Allocator>
 vector<T, Allocator>::vector(const vector& other) : _alloc(other._alloc)
-{}
+{
+	size_type count = other.size();
+
+	_vallocate(count);
+	std::uninitialized_copy(other._begin, other._end, _begin);
+	_end = _begin + count;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                  operator=                                 */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -26,6 +26,12 @@ class vector
 	typedef ft::reverse_iterator<iterator>       reverse_iterator;
 	typedef ft::reverse_iterator<const_iterator> const_reverse_iterator;
 
+  private:
+	pointer        _begin;
+	pointer        _end;
+	allocator_type _alloc;
+
+  public:
 	// (constructor)
 	vector(){};
 	explicit vector(const Allocator& alloc);

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -66,10 +66,10 @@ class vector
 	T*       data() { return static_cast<T*>(_begin); };
 	const T* data() const { return static_cast<const T*>(_begin); };
 	// ------------------------------ Iterators ----------------------------- //
-	iterator               begin(){};
-	const_iterator         begin() const {};
-	iterator               end(){};
-	const_iterator         end() const {};
+	iterator               begin() { return iterator(_begin); };
+	const_iterator         begin() const { return const_iterator(_begin); };
+	iterator               end() { return iterator(_end); };
+	const_iterator         end() const { return const_iterator(_end); };
 	reverse_iterator       rbegin(){};
 	const_reverse_iterator rbegin() const {};
 	reverse_iterator       rend(){};

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -55,8 +55,8 @@ class vector
 	reference       at(size_type pos);
 	const_reference at(size_type pos) const;
 	// operator[]
-	reference       operator[](size_type pos){};
-	const_reference operator[](size_type pos) const {};
+	reference       operator[](size_type pos) { return _begin[pos]; };
+	const_reference operator[](size_type pos) const { return _begin[pos]; };
 	// front
 	reference       front(){};
 	const_reference front() const {};

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -259,7 +259,7 @@ void vector<T, Alloc>::_vallocate(size_type n)
 	if (n > max_size())
 		throw std::logic_error("allocation size too large");
 	_begin   = _alloc.allocate(n);
-	_begin   = _end;
+	_end     = _begin;
 	_end_cap = _begin + n;
 }
 

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -165,13 +165,24 @@ void vector<T, Allocator>::assign(size_type count, const T& value)
 	for (size_type i = 0; i < count; ++i, ++current) {
 		*current = value;
 	}
-	_end += count;
+	_end = _begin + count;
 }
 
 template <class T, class Allocator>
 template <class InputIt>
 void vector<T, Allocator>::assign(InputIt first, InputIt last)
-{}
+{
+	size_type count = static_cast<size_type>(last - first);
+	pointer   current;
+
+	if (capacity() < count)
+		reserve(count);
+	current = _begin;
+	for (InputIt it = first; it != last; ++it, ++current) {
+		*current = *it;
+	}
+	_end = _begin + count;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                     at                                     */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -149,13 +149,15 @@ vector<T, Allocator>::operator=(const vector<T, Allocator>& other)
 template <class T, class Allocator>
 void vector<T, Allocator>::assign(size_type count, const T& value)
 {
-	pointer current = _begin;
+	pointer current;
 
-	if (size() < count)
+	if (capacity() < count)
 		reserve(count);
+	current = _begin;
 	for (size_type i = 0; i < count; ++i, ++current) {
 		*current = value;
 	}
+	_end += count;
 }
 
 template <class T, class Allocator>

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -189,11 +189,19 @@ void vector<T, Allocator>::assign(InputIt first, InputIt last)
 /* -------------------------------------------------------------------------- */
 template <class T, class Allocator>
 typename vector<T, Allocator>::reference vector<T, Allocator>::at(size_type pos)
-{}
+{
+	if (pos >= size())
+		throw std::out_of_range("index out of range");
+	return _begin[pos];
+}
 
 template <class T, class Allocator>
 typename vector<T, Allocator>::const_reference vector<T, Allocator>::at(size_type pos) const
-{}
+{
+	if (pos >= size())
+		throw std::out_of_range("index out of range");
+	return _begin[pos];
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                   reserve                                  */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -77,7 +77,7 @@ class vector
 	const_reverse_iterator rend() const {};
 	// ------------------------------ Capacity ------------------------------ //
 	bool      empty() const {};
-	size_type size() const {};
+	size_type size() const { return static_cast<size_type>(_end - _begin); };
 	size_type max_size() const {};
 	void      reserve(size_type new_cap);
 	size_type capacity() const {};

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -263,8 +263,8 @@ void vector<T, Allocator>::push_back(const T& value)
 	size_type new_size = size() + 1;
 	if (capacity() < new_size)
 		reserve(new_size);
-	_begin[new_size - 1] = value;
-	_end++;
+	_construct_at_end(1);
+	*(_end - 1) = value;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -297,9 +297,12 @@ void vector<T, Allocator>::insert(iterator pos, InputIt first, InputIt last,
 template <class T, class Allocator>
 typename vector<T, Allocator>::iterator vector<T, Allocator>::erase(iterator pos)
 {
-	std::copy(pos + 1, end(), pos);
+	difference_type count    = pos - begin();
+	pointer         position = _begin + count;
+
+	std::copy(position + 1, _end, position);
 	_destruct_at_end(1);
-	return pos;
+	return position;
 }
 
 template <class T, class Allocator>

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -213,12 +213,15 @@ typename vector<T, Allocator>::const_reference vector<T, Allocator>::at(size_typ
 template <class T, class Allocator>
 void vector<T, Allocator>::reserve(size_type new_cap)
 {
+	if (new_cap <= size())
+		return;
 	if (capacity() > new_cap)
 		return;
 	size_type _size     = size();
 	pointer   new_begin = _alloc.allocate(new_cap);
 	std::uninitialized_copy(_begin, _end, new_begin);
-	_alloc.destroy(_begin);
+	_destruct_at_end(_begin);
+	_alloc.deallocate(_begin, _size);
 
 	_begin   = new_begin;
 	_end     = _begin + _size;

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -78,9 +78,15 @@ class vector
 	// ------------------------------ Capacity ------------------------------ //
 	bool      empty() const {};
 	size_type size() const { return static_cast<size_type>(_end - _begin); };
-	size_type max_size() const {};
+	size_type max_size() const
+	{
+		return std::numeric_limits<difference_type>::max();
+	};
 	void      reserve(size_type new_cap);
-	size_type capacity() const {};
+	size_type capacity() const
+	{
+		return static_cast<size_type>(_end_cap - _begin);
+	};
 	/* ------------------------------ Modifiers ----------------------------- */
 	void clear(){};
 	// insert

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -138,7 +138,15 @@ vector<T, Allocator>::operator=(const vector<T, Allocator>& other)
 /* -------------------------------------------------------------------------- */
 template <class T, class Allocator>
 void vector<T, Allocator>::assign(size_type count, const T& value)
-{}
+{
+	pointer current = _begin;
+
+	if (size() < count)
+		reserve(count);
+	for (size_type i = 0; i < count; ++i, ++current) {
+		*current = value;
+	}
+}
 
 template <class T, class Allocator>
 template <class InputIt>

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -57,11 +57,11 @@ class vector
 	reference       operator[](size_type pos) { return _begin[pos]; };
 	const_reference operator[](size_type pos) const { return _begin[pos]; };
 	// front
-	reference       front(){};
-	const_reference front() const {};
+	reference       front() { return *_begin; };
+	const_reference front() const { return *_begin; };
 	// back
-	reference       back(){};
-	const_reference back() const {};
+	reference       back() { return *(_end - 1); };
+	const_reference back() const { return *(_end - 1); };
 	// data
 	T*       data() { return static_cast<T*>(_begin); };
 	const T* data() const { return static_cast<const T*>(_begin); };

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -4,6 +4,7 @@
 #include "iterators.hpp"
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 
 namespace ft {
 
@@ -95,6 +96,9 @@ class vector
 	void pop_back(){};
 	void resize(size_type count, T value = T()){};
 	void swap(vector& other){};
+
+  private:
+	void _vallocate(size_type n);
 };
 
 /* -------------------------------------------------------------------------- */
@@ -236,6 +240,20 @@ bool operator>=(const vector<T, Alloc>& lhs, const vector<T, Alloc>& rhs)
 template <class T, class Alloc>
 void swap(std::vector<T, Alloc>& lhs, std::vector<T, Alloc>& rhs)
 {}
+
+/* -------------------------------------------------------------------------- */
+/*                          private member functions                          */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Alloc>
+void vector<T, Alloc>::_vallocate(size_type n)
+{
+	if (n > max_size())
+		throw std::logic_error("allocation size too large");
+	_begin   = _alloc.allocate(n);
+	_begin   = _end;
+	_end_cap = _begin + n;
+}
 
 } // namespace ft
 

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -102,6 +102,7 @@ class vector
 
   private:
 	void _vallocate(size_type n);
+	void _construct_at_end(size_type n, T value);
 	void _construct_at_end(size_type n);
 	void _destruct_at_end(size_type n);
 	void _destruct_at_end(pointer new_last);
@@ -409,6 +410,17 @@ void vector<T, Alloc>::_vallocate(size_type n)
 	_begin   = _alloc.allocate(n);
 	_end     = _begin;
 	_end_cap = _begin + n;
+}
+
+template <class T, class Alloc>
+void vector<T, Alloc>::_construct_at_end(size_type n, T value)
+{
+	while (n > 0) {
+		_alloc.construct(_end);
+		*_end = value;
+		++_end;
+		--n;
+	}
 }
 
 template <class T, class Alloc>

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -35,14 +35,14 @@ class vector
 	allocator_type _alloc;
 
   public:
-	vector() : _begin(NULL), _end(NULL), _end_cap(NULL), _alloc(Allocator()){};
+	vector() : _begin(NULL), _end(NULL), _end_cap(NULL), _alloc(Allocator()) {}
 	explicit vector(const Allocator& alloc);
 	explicit vector(size_type count, const T& value = T(), const Allocator& alloc = Allocator());
 	template <class InputIt>
 	vector(InputIt first, InputIt last, const Allocator& alloc = Allocator());
 	vector(const vector& other);
 	// (destructor)
-	~vector(){};
+	~vector() {}
 	// operator=
 	vector& operator=(const vector& other);
 	// assign
@@ -50,40 +50,40 @@ class vector
 	template <class InputIt>
 	void assign(InputIt first, InputIt last);
 	// get_allocator
-	allocator_type get_allocator() const { return _alloc; };
+	allocator_type get_allocator() const { return _alloc; }
 	// --------------------------- Elements access -------------------------- //
 	// at
 	reference       at(size_type pos);
 	const_reference at(size_type pos) const;
 	// operator[]
-	reference       operator[](size_type pos) { return _begin[pos]; };
-	const_reference operator[](size_type pos) const { return _begin[pos]; };
+	reference       operator[](size_type pos) { return _begin[pos]; }
+	const_reference operator[](size_type pos) const { return _begin[pos]; }
 	// front
-	reference       front() { return *_begin; };
-	const_reference front() const { return *_begin; };
+	reference       front() { return *_begin; }
+	const_reference front() const { return *_begin; }
 	// back
-	reference       back() { return *(_end - 1); };
-	const_reference back() const { return *(_end - 1); };
+	reference       back() { return *(_end - 1); }
+	const_reference back() const { return *(_end - 1); }
 	// data
-	T*       data() { return static_cast<T*>(_begin); };
-	const T* data() const { return static_cast<const T*>(_begin); };
+	T*       data() { return static_cast<T*>(_begin); }
+	const T* data() const { return static_cast<const T*>(_begin); }
 	// ------------------------------ Iterators ----------------------------- //
-	iterator               begin() { return iterator(_begin); };
-	const_iterator         begin() const { return const_iterator(_begin); };
-	iterator               end() { return iterator(_end); };
-	const_iterator         end() const { return const_iterator(_end); };
-	reverse_iterator       rbegin() { return reverse_iterator(end()); };
-	const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); };
-	reverse_iterator       rend() { return reverse_iterator(begin()); };
-	const_reverse_iterator rend() const { return const_reverse_iterator(begin()); };
+	iterator               begin() { return iterator(_begin); }
+	const_iterator         begin() const { return const_iterator(_begin); }
+	iterator               end() { return iterator(_end); }
+	const_iterator         end() const { return const_iterator(_end); }
+	reverse_iterator       rbegin() { return reverse_iterator(end()); }
+	const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+	reverse_iterator       rend() { return reverse_iterator(begin()); }
+	const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
 	// ------------------------------ Capacity ------------------------------ //
-	bool      empty() const { return (size() == 0); };
-	size_type size() const { return static_cast<size_type>(_end - _begin); };
-	size_type max_size() const { return std::numeric_limits<difference_type>::max(); };
+	bool      empty() const { return (size() == 0); }
+	size_type size() const { return static_cast<size_type>(_end - _begin); }
+	size_type max_size() const { return std::numeric_limits<difference_type>::max(); }
 	void      reserve(size_type new_cap);
-	size_type capacity() const { return static_cast<size_type>(_end_cap - _begin); };
+	size_type capacity() const { return static_cast<size_type>(_end_cap - _begin); }
 	/* ------------------------------ Modifiers ----------------------------- */
-	void clear() { _destruct_at_end(_begin); };
+	void clear() { _destruct_at_end(_begin); }
 	// insert
 	iterator insert(iterator pos, const T& value);
 	void     insert(iterator pos, size_type count, const T& value);
@@ -96,8 +96,8 @@ class vector
 	// push_back
 	void push_back(const T& value);
 	// pop_back
-	void pop_back() { _destruct_at_end(1); };
-	void resize(size_type count, T value = T()){};
+	void pop_back() { _destruct_at_end(1); }
+	void resize(size_type count, T value = T()) {}
 	void swap(vector& other);
 
   private:

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -82,7 +82,7 @@ class vector
 	void      reserve(size_type new_cap);
 	size_type capacity() const { return static_cast<size_type>(_end_cap - _begin); };
 	/* ------------------------------ Modifiers ----------------------------- */
-	void clear();
+	void clear() { _destruct_at_end(_begin); };
 	// insert
 	iterator insert(iterator pos, const T& value);
 	void     insert(iterator pos, size_type count, const T& value);
@@ -222,18 +222,6 @@ void vector<T, Allocator>::reserve(size_type new_cap)
 	_begin   = new_begin;
 	_end     = _begin + _size;
 	_end_cap = _begin + new_cap;
-}
-
-/* -------------------------------------------------------------------------- */
-/*                                    clear                                   */
-/* -------------------------------------------------------------------------- */
-template <class T, class Allocator>
-void vector<T, Allocator>::clear()
-{
-	for (pointer ptr = _begin; ptr == _end; ++ptr) {
-		_alloc.destroy(ptr);
-	}
-	_begin = _end;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -3,6 +3,7 @@
 
 #include "algorithm.hpp"
 #include "iterators.hpp"
+#include "type_traits.hpp"
 #include <iostream>
 #include <memory>
 #include <stdexcept>
@@ -87,7 +88,8 @@ class vector
 	iterator insert(iterator pos, const T& value);
 	void     insert(iterator pos, size_type count, const T& value);
 	template <class InputIt>
-	void insert(iterator pos, InputIt first, InputIt last);
+	void insert(iterator pos, InputIt first, InputIt last,
+	    typename ft::enable_if<!ft::is_integral<InputIt>::value>::type* = 0);
 	// erase
 	iterator erase(iterator pos){};
 	iterator erase(iterator first, iterator last){};
@@ -267,7 +269,8 @@ void vector<T, Allocator>::insert(iterator pos, size_type count, const T& value)
 
 template <class T, class Allocator>
 template <class InputIt>
-void vector<T, Allocator>::insert(iterator pos, InputIt first, InputIt last)
+void vector<T, Allocator>::insert(iterator pos, InputIt first, InputIt last,
+    typename ft::enable_if<!ft::is_integral<InputIt>::value>::type*)
 {
 	difference_type count  = last - first;
 	difference_type offset = pos - begin();

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -10,7 +10,6 @@ namespace ft {
 template <class T, class Allocator = std::allocator<T> >
 class vector
 {
-  private:
   public:
 	typedef T                                 value_type;
 	typedef Allocator                         allocator_type;
@@ -32,7 +31,6 @@ class vector
 	allocator_type _alloc;
 
   public:
-	// (constructor)
 	vector(){};
 	explicit vector(const Allocator& alloc);
 	explicit vector(size_type count, const T& value = T(),
@@ -49,7 +47,7 @@ class vector
 	template <class InputIt>
 	void assign(InputIt first, InputIt last);
 	// get_allocator
-	allocator_type get_allocator() const {};
+	allocator_type get_allocator() const { return _alloc; };
 	// --------------------------- Elements access -------------------------- //
 	// at
 	reference       at(size_type pos);
@@ -102,20 +100,22 @@ class vector
 /*                                 constructor                                */
 /* -------------------------------------------------------------------------- */
 template <class T, class Allocator>
-vector<T, Allocator>::vector(const Allocator& alloc)
+vector<T, Allocator>::vector(const Allocator& alloc) : _alloc(alloc)
 {}
 
 template <class T, class Allocator>
 vector<T, Allocator>::vector(
-    size_type count, const T& value, const Allocator& alloc)
+    size_type count, const T& value, const Allocator& alloc) :
+    _alloc(alloc)
 {}
 template <class T, class Allocator>
 template <class InputIt>
 vector<T, Allocator>::vector(
-    InputIt first, InputIt last, const Allocator& alloc)
+    InputIt first, InputIt last, const Allocator& alloc) :
+    _alloc(alloc)
 {}
 template <class T, class Allocator>
-vector<T, Allocator>::vector(const vector& other)
+vector<T, Allocator>::vector(const vector& other) : _alloc(other._alloc)
 {}
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -81,7 +81,7 @@ class vector
 	void      reserve(size_type new_cap);
 	size_type capacity() const { return static_cast<size_type>(_end_cap - _begin); };
 	/* ------------------------------ Modifiers ----------------------------- */
-	void clear(){};
+	void clear();
 	// insert
 	iterator insert(iterator pos, const T& value);
 	void     insert(iterator pos, size_type count, const T& value);
@@ -192,6 +192,18 @@ void vector<T, Allocator>::reserve(size_type new_cap)
 	_begin   = new_begin;
 	_end     = _begin + _size;
 	_end_cap = _begin + new_cap;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                    clear                                   */
+/* -------------------------------------------------------------------------- */
+template <class T, class Allocator>
+void vector<T, Allocator>::clear()
+{
+	for (pointer ptr = _begin; ptr == _end; ++ptr) {
+		_alloc.destroy(ptr);
+	}
+	_begin = _end;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -70,10 +70,10 @@ class vector
 	const_iterator         begin() const { return const_iterator(_begin); };
 	iterator               end() { return iterator(_end); };
 	const_iterator         end() const { return const_iterator(_end); };
-	reverse_iterator       rbegin(){};
-	const_reverse_iterator rbegin() const {};
-	reverse_iterator       rend(){};
-	const_reverse_iterator rend() const {};
+	reverse_iterator       rbegin() { return reverse_iterator(end()); };
+	const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); };
+	reverse_iterator       rend() { return reverse_iterator(begin()); };
+	const_reverse_iterator rend() const { return const_reverse_iterator(begin()); };
 	// ------------------------------ Capacity ------------------------------ //
 	bool      empty() const { return (size() == 0); };
 	size_type size() const { return static_cast<size_type>(_end - _begin); };

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -91,7 +91,7 @@ class vector
 	iterator erase(iterator pos){};
 	iterator erase(iterator first, iterator last){};
 	// push_back
-	void push_back(const T& value){};
+	void push_back(const T& value);
 	void pop_back(){};
 	void resize(size_type count, T value = T()){};
 	void swap(vector& other){};
@@ -211,6 +211,19 @@ template <class InputIt>
 void vector<T, Allocator>::insert(iterator pos, InputIt first, InputIt last)
 {}
 // */
+
+/* -------------------------------------------------------------------------- */
+/*                                  push_back                                 */
+/* -------------------------------------------------------------------------- */
+template <class T, class Allocator>
+void vector<T, Allocator>::push_back(const T& value)
+{
+	size_type new_size = size() + 1;
+	if (capacity() < new_size)
+		reserve(new_size);
+	_begin[new_size - 1] = value;
+	_end++;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                            Non-member functions                            */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -35,8 +35,7 @@ class vector
   public:
 	vector() : _begin(NULL), _end(NULL), _end_cap(NULL), _alloc(Allocator()){};
 	explicit vector(const Allocator& alloc);
-	explicit vector(size_type count, const T& value = T(),
-	    const Allocator& alloc = Allocator());
+	explicit vector(size_type count, const T& value = T(), const Allocator& alloc = Allocator());
 	template <class InputIt>
 	vector(InputIt first, InputIt last, const Allocator& alloc = Allocator());
 	vector(const vector& other);
@@ -78,15 +77,9 @@ class vector
 	// ------------------------------ Capacity ------------------------------ //
 	bool      empty() const {};
 	size_type size() const { return static_cast<size_type>(_end - _begin); };
-	size_type max_size() const
-	{
-		return std::numeric_limits<difference_type>::max();
-	};
+	size_type max_size() const { return std::numeric_limits<difference_type>::max(); };
 	void      reserve(size_type new_cap);
-	size_type capacity() const
-	{
-		return static_cast<size_type>(_end_cap - _begin);
-	};
+	size_type capacity() const { return static_cast<size_type>(_end_cap - _begin); };
 	/* ------------------------------ Modifiers ----------------------------- */
 	void clear(){};
 	// insert
@@ -116,8 +109,7 @@ vector<T, Allocator>::vector(const Allocator& alloc) :
 {}
 
 template <class T, class Allocator>
-vector<T, Allocator>::vector(
-    size_type count, const T& value, const Allocator& alloc) :
+vector<T, Allocator>::vector(size_type count, const T& value, const Allocator& alloc) :
     _alloc(alloc)
 {
 	_vallocate(count);
@@ -126,9 +118,7 @@ vector<T, Allocator>::vector(
 
 template <class T, class Allocator>
 template <class InputIt>
-vector<T, Allocator>::vector(
-    InputIt first, InputIt last, const Allocator& alloc) :
-    _alloc(alloc)
+vector<T, Allocator>::vector(InputIt first, InputIt last, const Allocator& alloc) : _alloc(alloc)
 {
 	size_type count = static_cast<size_type>(last - first);
 	_vallocate(count);
@@ -150,8 +140,7 @@ vector<T, Allocator>::vector(const vector& other) : _alloc(other._alloc)
 /*                                  operator=                                 */
 /* -------------------------------------------------------------------------- */
 template <class T, class Allocator>
-vector<T, Allocator>&
-vector<T, Allocator>::operator=(const vector<T, Allocator>& other)
+vector<T, Allocator>& vector<T, Allocator>::operator=(const vector<T, Allocator>& other)
 {}
 
 /* -------------------------------------------------------------------------- */
@@ -184,8 +173,7 @@ typename vector<T, Allocator>::reference vector<T, Allocator>::at(size_type pos)
 {}
 
 template <class T, class Allocator>
-typename vector<T, Allocator>::const_reference
-vector<T, Allocator>::at(size_type pos) const
+typename vector<T, Allocator>::const_reference vector<T, Allocator>::at(size_type pos) const
 {}
 
 /* -------------------------------------------------------------------------- */
@@ -211,8 +199,7 @@ void vector<T, Allocator>::reserve(size_type new_cap)
 /* -------------------------------------------------------------------------- */
 // /*
 template <class T, class Allocator>
-typename vector<T, Allocator>::iterator
-vector<T, Allocator>::insert(iterator pos, const T& value)
+typename vector<T, Allocator>::iterator vector<T, Allocator>::insert(iterator pos, const T& value)
 {}
 
 template <class T, class Allocator>

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -98,6 +98,8 @@ class vector
 
   private:
 	void _vallocate(size_type n);
+	void _construct_at_end(size_type n);
+	void _destruct_at_end(pointer new_last);
 };
 
 /* -------------------------------------------------------------------------- */
@@ -311,6 +313,25 @@ void vector<T, Alloc>::_vallocate(size_type n)
 	_begin   = _alloc.allocate(n);
 	_end     = _begin;
 	_end_cap = _begin + n;
+}
+
+template <class T, class Alloc>
+void vector<T, Alloc>::_construct_at_end(size_type n)
+{
+	while (n > 0) {
+		_alloc.construct(_end);
+		++_end;
+		--n;
+	}
+}
+
+template <class T, class Alloc>
+void vector<T, Alloc>::_destruct_at_end(pointer new_last)
+{
+	while (_end != new_last) {
+		--_end;
+		_alloc.destroy(_end);
+	}
 }
 
 } // namespace ft

--- a/test_srcs/Log.cpp
+++ b/test_srcs/Log.cpp
@@ -20,19 +20,16 @@ void Log::write_to_logfile(t_unit_subtests& current_test)
 {
 	static const char* prev_func_name;
 
-	if (!prev_func_name
-	    || strcmp(prev_func_name, current_test.func_name) != 0) {
+	if (!prev_func_name || strcmp(prev_func_name, current_test.func_name) != 0) {
 		_logfile_stream << "[" << current_test.func_name << "]" << std::endl;
 		prev_func_name = current_test.func_name;
 	}
 	std::string display_subtest_name(current_test.subtest_name);
-	_logfile_stream << std::left << std::setw(30) << display_subtest_name
-	                << ": ";
+	_logfile_stream << std::left << std::setw(30) << display_subtest_name << ": ";
 	if (current_test.result == TEST_SUCCESS)
 		_logfile_stream << "[PASS]" << std::endl;
 	else
-		_logfile_stream << "[FAIL: " << _current_explanation << "]"
-		                << std::endl;
+		_logfile_stream << "[FAIL: " << _current_explanation << "]" << std::endl;
 }
 
 void Log::_open_logfile()

--- a/test_srcs/UnitTester.cpp
+++ b/test_srcs/UnitTester.cpp
@@ -123,8 +123,7 @@ void UnitTester::_print_subheader(const std::string& header)
 	std::cout << std::setfill('=');
 	std::cout << std::setw(leftside) << " ";
 	std::cout << header;
-	std::cout << std::setw(fill_width - leftside) << std::left << " "
-	          << std::endl;
+	std::cout << std::setw(fill_width - leftside) << std::left << " " << std::endl;
 	std::cout << std::setfill(' ');
 }
 
@@ -185,8 +184,8 @@ void UnitTester::_display_total()
 	std::cout << _cnt_success << "/" << _cnt_total << COLOR_CLEAR;
 
 	int score_persentage = 100 * _cnt_success / _cnt_total;
-	std::cout << " tests passed (" << COLOR_BORD << score_persentage << "%"
-	          << COLOR_CLEAR << ")" << std::endl;
+	std::cout << " tests passed (" << COLOR_BORD << score_persentage << "%" << COLOR_CLEAR << ")"
+	          << std::endl;
 }
 
 void UnitTester::run_tests(void)

--- a/test_srcs/UnitTester.hpp
+++ b/test_srcs/UnitTester.hpp
@@ -31,16 +31,14 @@ typedef enum e_stl_types
 	MAP
 } t_stl_types;
 
-typedef struct s_unit_tests
-{
+typedef struct s_unit_tests {
 	const char* func_name;
 	void (*func_test_ptr)();
 	t_test_status result;
 	t_stl_types   type;
 } t_unit_tests;
 
-typedef struct s_unit_subtests
-{
+typedef struct s_unit_subtests {
 	const char* func_name;
 	const char* subtest_name;
 	void (*func_test_ptr)();

--- a/test_srcs/VectorTest.cpp
+++ b/test_srcs/VectorTest.cpp
@@ -20,16 +20,16 @@ t_unit_tests func_test_table[] = {
 	{                 "vector_at",                  vector_at, FAIL, VECTOR},
 	{ "vector_subscript_operator",  vector_subscript_operator, FAIL, VECTOR},
 	{              "vector_front",               vector_front, FAIL, VECTOR},
-	{               "vector_back",                vector_back, FAIL, VECTOR},
+    {               "vector_back",                vector_back, FAIL, VECTOR},
 	{               "vector_data",                vector_data, FAIL, VECTOR},
  // ------------------------------ Iterators ----------------------------- //
 	{              "vector_begin",               vector_begin, FAIL, VECTOR},
-	{                "vector_end",                 vector_end, FAIL, VECTOR},
+    {                "vector_end",                 vector_end, FAIL, VECTOR},
 	{             "vector_rbegin",              vector_rbegin, FAIL, VECTOR},
-	{               "vector_rend",                vector_rend, FAIL, VECTOR},
+    {               "vector_rend",                vector_rend, FAIL, VECTOR},
  // ------------------------------ Capacity ----------------------------- //
 	{              "vector_empty",               vector_empty, FAIL, VECTOR},
-	{               "vector_size",                vector_size, FAIL, VECTOR},
+    {               "vector_size",                vector_size, FAIL, VECTOR},
 	{           "vector_max_size",            vector_max_size, FAIL, VECTOR},
 	{            "vector_reserve",             vector_reserve, FAIL, VECTOR},
 	{           "vector_capacity",            vector_capacity, FAIL, VECTOR},
@@ -40,7 +40,7 @@ t_unit_tests func_test_table[] = {
 	{          "vector_push_back",           vector_push_back, FAIL, VECTOR},
 	{           "vector_pop_back",            vector_pop_back, FAIL, VECTOR},
 	{             "vector_resize",              vector_resize, FAIL, VECTOR},
-	{               "vector_swap",                vector_swap, FAIL, VECTOR},
+    {               "vector_swap",                vector_swap, FAIL, VECTOR},
  // ------------------------ Non-member functions ------------------------ //
 	{         "vector_operator_e",          vector_operator_e, FAIL, VECTOR},
 	{        "vector_operator_ne",         vector_operator_ne, FAIL, VECTOR},
@@ -49,7 +49,7 @@ t_unit_tests func_test_table[] = {
 	{         "vector_operator_g",          vector_operator_g, FAIL, VECTOR},
 	{        "vector_operator_ge",         vector_operator_ge, FAIL, VECTOR},
 	{           "vector_std_swap",            vector_std_swap, FAIL, VECTOR},
-	{                        "\0",                       NULL, FAIL, VECTOR}
+    {                        "\0",                       NULL, FAIL, VECTOR}
 };
 
 void _set_int_array(int* array, int size, bool accend)

--- a/test_srcs/VectorTest.hpp
+++ b/test_srcs/VectorTest.hpp
@@ -62,13 +62,12 @@ void vector_std_swap();
 
 extern t_unit_tests func_test_table[TABLE_SIZE];
 
-void             _set_int_array(int* array, int size = 12, bool accend = false);
-ft::vector<int>  _set_vector(int size = 6, bool accend = false);
-ft::vector<char> _set_vector_char(size_t size = 6, bool accend = false);
-ft::vector<std::string>
-     _set_vector_string(size_t size = 6, bool random = false);
-void _set_compare_vectors(ft::vector<int>& ft_data, std::vector<int>& std_data,
-    int size = 6, bool accend = false);
+void                    _set_int_array(int* array, int size = 12, bool accend = false);
+ft::vector<int>         _set_vector(int size = 6, bool accend = false);
+ft::vector<char>        _set_vector_char(size_t size = 6, bool accend = false);
+ft::vector<std::string> _set_vector_string(size_t size = 6, bool random = false);
+void                    _set_compare_vectors(
+                       ft::vector<int>& ft_data, std::vector<int>& std_data, int size = 6, bool accend = false);
 
 template <class T>
 void _compare_vectors(ft::vector<T>& ft_vec, std::vector<T>& std_vec)

--- a/test_srcs/VectorTest_Capacity.cpp
+++ b/test_srcs/VectorTest_Capacity.cpp
@@ -81,9 +81,8 @@ void _vector_max_size_multiple()
 	set_explanation_("multiple vectors does not return the same max value");
 	UnitTester::assert_(ft.max_size() == ft2.max_size());
 	set_explanation_("returned value not max");
-	UnitTester::assert_(
-	    (ft.max_size() == ft.get_allocator().max_size())
-	    || (ft.max_size() == std::numeric_limits<ptrdiff_t>::max()));
+	UnitTester::assert_((ft.max_size() == ft.get_allocator().max_size())
+	                    || (ft.max_size() == std::numeric_limits<ptrdiff_t>::max()));
 }
 
 void _vector_max_size_compare()

--- a/test_srcs/VectorTest_NonMemberFunctions.cpp
+++ b/test_srcs/VectorTest_NonMemberFunctions.cpp
@@ -224,8 +224,7 @@ void vector_operator_l()
 
 void _vector_operator_le_true()
 {
-	set_explanation_(
-	    "std::string vector size difference not evaluated correctly");
+	set_explanation_("std::string vector size difference not evaluated correctly");
 	int                     size = 10;
 	ft::vector<std::string> ft_0 = _set_vector_string(size, false);
 	ft::vector<std::string> ft_1 = _set_vector_string(size, false);
@@ -347,8 +346,7 @@ void vector_operator_g()
 
 void _vector_operator_ge_true()
 {
-	set_explanation_(
-	    "std::string vector size difference not evaluated correctly");
+	set_explanation_("std::string vector size difference not evaluated correctly");
 	ft::vector<std::string> ft_1 = _set_vector_string();
 	ft::vector<std::string> ft_2 = ft_1;
 
@@ -361,8 +359,7 @@ void _vector_operator_ge_true()
 
 void _vector_operator_ge_false()
 {
-	set_explanation_(
-	    "std::string vector size difference not evaluated correctly");
+	set_explanation_("std::string vector size difference not evaluated correctly");
 	int                     size = 12;
 	ft::vector<std::string> ft_1 = _set_vector_string(size, false);
 	ft::vector<std::string> ft_2 = ft_1;


### PR DESCRIPTION
- add: private members
- feat: get_allocator()
- add: tmporaly constructors
- add: reserve()
- add: assign()
- add: _vallocate()
- add: size()
- add: operator[]
- add: max_size(), capacity()
- fix: assign() _begin, _end setting
- fix: _vallocate() _begin always NULL
- update: fix and implement constructors
- style: update clang format width = 100
- add: data()
- add: forward iterator funcs
- add: empty()
- add: push_back()
- add: front(), back()
- add: clear()
- add: operator=
- update: assign()
- add: at()
- add: algorithm.hpp; equal, lexicographical_compare
- add: reverse_iterator definitions; rbegin(), rend()
- add: _construct / _destruct_at_end()
- add: compare operators
- add: pop_back()
- update: push_back(); use _construct_at_end()
- update: clear(); use _destruct_at_end()
- update: pop_back to one-line
- add: swap(), member and non-member
- add: iterator friend operator+/-, operator-
- style: reorder and add comments for random_access_iterator funcs
- add: insert()
- fix: iterator operator+
- update: reserve to check size and deallocate
- add: enable_if
- style: update format;  SplitEmptyRecord = false
- update: enable_if; DONE
- add: is_integral
- add: SFINAE for insert()
- add: implement reverse_iterator functions
- fix: random_access_iterator operator++ / --
- add: _destruct_at_end overload
- add: erase()
- style: rename _current -> current
- style: delete trailing commas after function definitioins
- update: reverse_iterator 2 funcs
- add: _construct_at_end overload
- add: resize()
- fix: bugs related to comparisons
- fix: erase for the first element
- fix: reverse_iterator inc/dec
- update: max_size()
