### PR TITLE
fix/#34bugs detected bymil42 tester

### DIFF
--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -33,8 +33,8 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		return *this;
 	}
 
-	reference operator*() { return *__i; }
-	pointer   operator->() { return __i; }
+	reference operator*() const { return *__i; }
+	pointer   operator->() const { return __i; }
 	reference operator[](difference_type n) const { return __i[n]; }
 
 	/* ------------------------- Advances / Decrements ------------------------- */

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -33,9 +33,9 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		return *this;
 	}
 
-	reference   operator*() { return *__i; }
-	pointer     operator->() { return __i; }
-	value_type& operator[](difference_type n) const { return *(__i + n); }
+	reference operator*() { return *__i; }
+	pointer   operator->() { return __i; }
+	reference operator[](difference_type n) const { return __i[n]; }
 
 	/* ------------------------- Advances / Decrements ------------------------- */
 	random_access_iterator& operator++()

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -10,12 +10,12 @@ template <class T>
 class random_access_iterator : public std::iterator<std::random_access_iterator_tag, T>
 {
   public:
-	typedef T*                                              iterator_type;
-	typedef typename iterator_traits<T*>::difference_type   difference_type;
-	typedef typename iterator_traits<T*>::value_type        value_type;
-	typedef typename iterator_traits<T*>::pointer           pointer;
-	typedef typename iterator_traits<T*>::reference         reference;
-	typedef typename iterator_traits<T*>::iterator_category iterator_category;
+	typedef T*                                                         iterator_type;
+	typedef typename iterator_traits<iterator_type>::difference_type   difference_type;
+	typedef typename iterator_traits<iterator_type>::value_type        value_type;
+	typedef typename iterator_traits<iterator_type>::pointer           pointer;
+	typedef typename iterator_traits<iterator_type>::reference         reference;
+	typedef typename iterator_traits<iterator_type>::iterator_category iterator_category;
 
   private:
 	pointer __i;

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -24,13 +24,16 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	// (constructor)
 	random_access_iterator() : __i(NULL) {}
 	random_access_iterator(T* pointer) : __i(pointer) {}
-	random_access_iterator(random_access_iterator const& other) : __i(other.__i) {}
+	template <class U>
+	random_access_iterator(random_access_iterator<U> const& other) : __i(other.base())
+	{}
 	// (destructor)
 	~random_access_iterator() {}
 
-	random_access_iterator& operator=(random_access_iterator const& other)
+	template <class U>
+	random_access_iterator& operator=(random_access_iterator<U> const& other)
 	{
-		__i = other.__i;
+		__i = other.base();
 		return *this;
 	}
 	iterator_type base() const { return __i; }

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -33,10 +33,9 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		return *this;
 	}
 
-	reference operator*() { return *__i; }
-	pointer   operator->() { return __i; }
-
-	// operator[]
+	reference   operator*() { return *__i; }
+	pointer     operator->() { return __i; }
+	value_type& operator[](difference_type n) const { return *(__i + n); }
 
 	/* ------------------------- Advances / Decrements ------------------------- */
 	random_access_iterator& operator++()

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -70,8 +70,16 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		__i -= rhs;
 		return *this;
 	}
-	// operator+=
-	// operator-=
+	random_access_iterator& operator+=(difference_type n)
+	{
+		__i += n;
+		return *this;
+	}
+	random_access_iterator& operator-=(difference_type n)
+	{
+		__i -= n;
+		return *this;
+	}
 
 	/* -------------------------- Non-member functions ------------------------- */
 	friend bool operator==(const random_access_iterator& lhs, const random_access_iterator& rhs)

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -91,43 +91,44 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 	{
 		return (lhs.__i < rhs.__i);
 	}
-	/* 	the rest implemented outside of this class */
-
-	friend random_access_iterator operator+(difference_type n, const random_access_iterator& it)
-	{
-		random_access_iterator tmp = it;
-		tmp.__i += n;
-		return tmp;
-	}
-	friend difference_type
-	operator-(const random_access_iterator& lhs, const random_access_iterator& rhs)
-	{
-		return (lhs.__i - rhs.__i);
-	}
 };
 
-template <class T>
-bool operator!=(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+template <class _Iter1, class _Iter2>
+bool operator==(
+    const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
+{
+	return (lhs.base() == rhs.base());
+}
+
+template <class _Iter1, class _Iter2>
+bool operator<(const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
+{
+	return (lhs.base() < rhs.base());
+}
+
+template <class _Iter1, class _Iter2>
+bool operator!=(
+    const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
 {
 	return (!(lhs == rhs));
 }
-template <class T>
-bool operator<(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
-{
-	return (lhs.__i < rhs.__i);
-}
-template <class T>
-bool operator<=(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+
+template <class _Iter1, class _Iter2>
+bool operator<=(
+    const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
 {
 	return (lhs < rhs || lhs == rhs);
 }
-template <class T>
-bool operator>(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+
+template <class _Iter1, class _Iter2>
+bool operator>(const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
 {
 	return (!(lhs < rhs) && !(lhs == rhs));
 }
-template <class T>
-bool operator>=(const random_access_iterator<T>& lhs, const random_access_iterator<T>& rhs)
+
+template <class _Iter1, class _Iter2>
+bool operator>=(
+    const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
 {
 	return !(lhs < rhs);
 }

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -64,15 +64,13 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		--__i;
 		return tmp;
 	}
-	random_access_iterator& operator+(difference_type rhs)
+	random_access_iterator operator+(difference_type n) const
 	{
-		__i += rhs;
-		return *this;
+		return random_access_iterator(__i + n);
 	}
-	random_access_iterator& operator-(difference_type rhs)
+	random_access_iterator operator-(difference_type n) const
 	{
-		__i -= rhs;
-		return *this;
+		return random_access_iterator(__i - n);
 	}
 	random_access_iterator& operator+=(difference_type n)
 	{

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -10,6 +10,7 @@ template <class T>
 class random_access_iterator : public std::iterator<std::random_access_iterator_tag, T>
 {
   public:
+	typedef T*                                              iterator_type;
 	typedef typename iterator_traits<T*>::difference_type   difference_type;
 	typedef typename iterator_traits<T*>::value_type        value_type;
 	typedef typename iterator_traits<T*>::pointer           pointer;
@@ -32,10 +33,10 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		__i = other.__i;
 		return *this;
 	}
-
-	reference operator*() const { return *__i; }
-	pointer   operator->() const { return __i; }
-	reference operator[](difference_type n) const { return __i[n]; }
+	iterator_type base() const { return __i; }
+	reference     operator*() const { return *__i; }
+	pointer       operator->() const { return __i; }
+	reference     operator[](difference_type n) const { return __i[n]; }
 
 	/* ------------------------- Advances / Decrements ------------------------- */
 	random_access_iterator& operator++()

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -116,27 +116,27 @@ template <class _Iter1, class _Iter2>
 bool operator!=(
     const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
 {
-	return (!(lhs == rhs));
+	return (lhs.base() != rhs.base());
 }
 
 template <class _Iter1, class _Iter2>
 bool operator<=(
     const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
 {
-	return (lhs < rhs || lhs == rhs);
+	return (lhs.base() <= rhs.base());
 }
 
 template <class _Iter1, class _Iter2>
 bool operator>(const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
 {
-	return (!(lhs < rhs) && !(lhs == rhs));
+	return (lhs.base() > rhs.base());
 }
 
 template <class _Iter1, class _Iter2>
 bool operator>=(
     const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
 {
-	return !(lhs < rhs);
+	return (lhs.base() >= rhs.base());
 }
 
 } // namespace ft

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -81,17 +81,22 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 		__i -= n;
 		return *this;
 	}
-
-	/* -------------------------- Non-member functions ------------------------- */
-	friend bool operator==(const random_access_iterator& lhs, const random_access_iterator& rhs)
-	{
-		return (lhs.__i == rhs.__i);
-	}
-	friend bool operator<(const random_access_iterator& lhs, const random_access_iterator& rhs)
-	{
-		return (lhs.__i < rhs.__i);
-	}
 };
+
+/* -------------------------- Non-member functions ------------------------- */
+template <class _Iter>
+random_access_iterator<_Iter> operator+(typename random_access_iterator<_Iter>::difference_type n,
+    const random_access_iterator<_Iter>&                                                        it)
+{
+	return random_access_iterator<_Iter>(it.base() + n);
+}
+
+template <class _Iter1, class _Iter2>
+typename random_access_iterator<_Iter1>::difference_type
+operator-(const random_access_iterator<_Iter1>& lhs, const random_access_iterator<_Iter2>& rhs)
+{
+	return (lhs.base() - rhs.base());
+}
 
 template <class _Iter1, class _Iter2>
 bool operator==(

--- a/includes/iterators.hpp
+++ b/includes/iterators.hpp
@@ -86,8 +86,9 @@ class random_access_iterator : public std::iterator<std::random_access_iterator_
 
 	friend random_access_iterator operator+(difference_type n, const random_access_iterator& it)
 	{
-		it.__i += n;
-		return it;
+		random_access_iterator tmp = it;
+		tmp.__i += n;
+		return tmp;
 	}
 	friend difference_type
 	operator-(const random_access_iterator& lhs, const random_access_iterator& rhs)

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -42,7 +42,7 @@ class reverse_iterator
 	pointer operator->() const
 	{
 		Iter tmp = current;
-		return &--tmp;
+		return &operator*();
 	}
 	reference         operator[](difference_type n) const { return current[n]; }
 	reverse_iterator& operator++()

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -86,15 +86,13 @@ template <class _Iter>
 reverse_iterator<_Iter>
 operator+(typename reverse_iterator<_Iter>::difference_type n, const reverse_iterator<_Iter>& it)
 {
-	reverse_iterator<_Iter> tmp = it;
-	tmp.base() += n;
-	return tmp;
+	return reverse_iterator<_Iter>(it.base() - n);
 }
 template <class _Iter1, class _Iter2>
 typename reverse_iterator<_Iter1>::difference_type
 operator-(const reverse_iterator<_Iter1>& lhs, const reverse_iterator<_Iter2>& rhs)
 {
-	return (lhs.base() - rhs.base());
+	return (rhs.base() - lhs.base());
 }
 
 template <class Iterator1, class Iterator2>

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -67,18 +67,8 @@ class reverse_iterator
 		++current;
 		return tmp;
 	}
-	reverse_iterator operator+(difference_type n) const
-	{
-		Iter tmp = current;
-		tmp -= n;
-		return reverse_iterator(tmp);
-	}
-	reverse_iterator operator-(difference_type n) const
-	{
-		Iter tmp = current;
-		tmp += n;
-		return reverse_iterator(tmp);
-	}
+	reverse_iterator  operator+(difference_type n) const { return reverse_iterator(current - n); }
+	reverse_iterator  operator-(difference_type n) const { return reverse_iterator(current + n); }
 	reverse_iterator& operator+=(difference_type n)
 	{
 		current -= n;

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -90,6 +90,17 @@ class reverse_iterator
 		return *this;
 	}
 
+	friend reverse_iterator operator+(difference_type n, const reverse_iterator& it)
+	{
+		reverse_iterator tmp = it;
+		tmp.current += n;
+		return tmp;
+	}
+	friend difference_type operator-(const reverse_iterator& lhs, const reverse_iterator& rhs)
+	{
+		return (lhs.current - rhs.current);
+	}
+
 	/* ------------------------ Non-member functions ------------------------ */
 	template <class Iterator1, class Iterator2>
 	friend bool operator==(
@@ -129,15 +140,6 @@ class reverse_iterator
 	}
 };
 
-// template <class Iter>
-// reverse_iterator<Iter>
-// operator+(typename reverse_iterator<Iter>::difference_type n, const reverse_iterator<Iter>& it)
-// {}
-
-// template <class Iterator>
-// typename reverse_iterator<Iterator>::difference_type
-// operator-(const reverse_iterator<Iterator>& lhs, const reverse_iterator<Iterator>& rhs)
-// {}
 } // namespace ft
 
 #endif /* REVERSE_ITERATOR_HPP */

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -21,7 +21,7 @@ class reverse_iterator
 
   public:
 	// (constructor)
-	reverse_iterator() : current(Iter()) {}
+	reverse_iterator() : current(iterator_type()) {}
 	explicit reverse_iterator(iterator_type x) : current(x) {}
 	template <class U>
 	reverse_iterator(const reverse_iterator<U>& other) : current(other.base())
@@ -36,13 +36,13 @@ class reverse_iterator
 	iterator_type base() const { return current; }
 	reference     operator*() const
 	{
-		Iter tmp = current;
+		iterator_type tmp = current;
 		return *--tmp;
 	}
 	pointer operator->() const
 	{
-		Iter tmp = current;
-		return &operator*();
+		iterator_type tmp = current;
+		return &      operator*();
 	}
 	reference         operator[](difference_type n) const { return *(*this + n); }
 	reverse_iterator& operator++()

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -44,7 +44,7 @@ class reverse_iterator
 		Iter tmp = current;
 		return &--tmp;
 	}
-	value_type&       operator[](difference_type n) const { return *(current + n); }
+	reference         operator[](difference_type n) const { return current[n]; }
 	reverse_iterator& operator++()
 	{
 		--current;

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -89,20 +89,24 @@ class reverse_iterator
 		current += n;
 		return *this;
 	}
-
-	friend reverse_iterator operator+(difference_type n, const reverse_iterator& it)
-	{
-		reverse_iterator tmp = it;
-		tmp.current += n;
-		return tmp;
-	}
-	friend difference_type operator-(const reverse_iterator& lhs, const reverse_iterator& rhs)
-	{
-		return (lhs.current - rhs.current);
-	}
 };
 
 /* ------------------------ Non-member functions ------------------------ */
+template <class _Iter>
+reverse_iterator<_Iter>
+operator+(typename reverse_iterator<_Iter>::difference_type n, const reverse_iterator<_Iter>& it)
+{
+	reverse_iterator<_Iter> tmp = it;
+	tmp.base() += n;
+	return tmp;
+}
+template <class _Iter1, class _Iter2>
+typename reverse_iterator<_Iter1>::difference_type
+operator-(const reverse_iterator<_Iter1>& lhs, const reverse_iterator<_Iter2>& rhs)
+{
+	return (lhs.base() - rhs.base());
+}
+
 template <class Iterator1, class Iterator2>
 bool operator==(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 {

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -24,13 +24,13 @@ class reverse_iterator
 	reverse_iterator() : current(Iter()) {}
 	explicit reverse_iterator(iterator_type x) : current(x) {}
 	template <class U>
-	reverse_iterator(const reverse_iterator<U>& other) : current(other.current)
+	reverse_iterator(const reverse_iterator<U>& other) : current(other.base())
 	{}
 	// operator=
 	template <class U>
 	reverse_iterator& operator=(const reverse_iterator<U>& other)
 	{
-		current = other.current;
+		current = other.base();
 		return *this;
 	}
 	iterator_type base() const { return current; }

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -44,7 +44,7 @@ class reverse_iterator
 		Iter tmp = current;
 		return &operator*();
 	}
-	reference         operator[](difference_type n) const { return current[n]; }
+	reference         operator[](difference_type n) const { return *(*this + n); }
 	reverse_iterator& operator++()
 	{
 		--current;

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -71,13 +71,13 @@ class reverse_iterator
 	{
 		Iter tmp = current;
 		tmp -= n;
-		return tmp;
+		return reverse_iterator(tmp);
 	}
 	reverse_iterator operator-(difference_type n) const
 	{
 		Iter tmp = current;
 		tmp += n;
-		return tmp;
+		return reverse_iterator(tmp);
 	}
 	reverse_iterator& operator+=(difference_type n)
 	{

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -103,38 +103,38 @@ class reverse_iterator
 
 	/* ------------------------ Non-member functions ------------------------ */
 	template <class Iterator1, class Iterator2>
-	friend bool operator==(
-	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
+	friend bool
+	operator==(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 	{
 		return (lhs.base() == rhs.base());
 	}
 	template <class Iterator1, class Iterator2>
-	friend bool operator!=(
-	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
+	friend bool
+	operator!=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 	{
 		return (lhs.base() != rhs.base());
 	}
 	template <class Iterator1, class Iterator2>
-	friend bool operator<(
-	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
+	friend bool
+	operator<(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 	{
 		return (lhs.base() < rhs.base());
 	}
 	template <class Iterator1, class Iterator2>
-	friend bool operator<=(
-	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
+	friend bool
+	operator<=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 	{
 		return (lhs.base() <= rhs.base());
 	}
 	template <class Iterator1, class Iterator2>
-	friend bool operator>(
-	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
+	friend bool
+	operator>(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 	{
 		return (lhs.base() > rhs.base());
 	}
 	template <class Iterator1, class Iterator2>
-	friend bool operator>=(
-	    const std::reverse_iterator<Iterator1>& lhs, const std::reverse_iterator<Iterator2>& rhs)
+	friend bool
+	operator>=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 	{
 		return (lhs.base() >= rhs.base());
 	}

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -108,22 +108,22 @@ bool operator!=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<I
 template <class Iterator1, class Iterator2>
 bool operator<(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 {
-	return (lhs.base() < rhs.base());
+	return (lhs.base() > rhs.base());
 }
 template <class Iterator1, class Iterator2>
 bool operator<=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 {
-	return (lhs.base() <= rhs.base());
+	return (lhs.base() >= rhs.base());
 }
 template <class Iterator1, class Iterator2>
 bool operator>(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 {
-	return (lhs.base() > rhs.base());
+	return (lhs.base() < rhs.base());
 }
 template <class Iterator1, class Iterator2>
 bool operator>=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
 {
-	return (lhs.base() >= rhs.base());
+	return (lhs.base() <= rhs.base());
 }
 
 } // namespace ft

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -44,7 +44,7 @@ class reverse_iterator
 		Iter tmp = current;
 		return &--tmp;
 	}
-	// /*unspecified*/   operator[](difference_type n) const;
+	value_type&       operator[](difference_type n) const { return *(current + n); }
 	reverse_iterator& operator++()
 	{
 		--current;

--- a/includes/reverse_iterator.hpp
+++ b/includes/reverse_iterator.hpp
@@ -100,45 +100,39 @@ class reverse_iterator
 	{
 		return (lhs.current - rhs.current);
 	}
-
-	/* ------------------------ Non-member functions ------------------------ */
-	template <class Iterator1, class Iterator2>
-	friend bool
-	operator==(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
-	{
-		return (lhs.base() == rhs.base());
-	}
-	template <class Iterator1, class Iterator2>
-	friend bool
-	operator!=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
-	{
-		return (lhs.base() != rhs.base());
-	}
-	template <class Iterator1, class Iterator2>
-	friend bool
-	operator<(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
-	{
-		return (lhs.base() < rhs.base());
-	}
-	template <class Iterator1, class Iterator2>
-	friend bool
-	operator<=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
-	{
-		return (lhs.base() <= rhs.base());
-	}
-	template <class Iterator1, class Iterator2>
-	friend bool
-	operator>(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
-	{
-		return (lhs.base() > rhs.base());
-	}
-	template <class Iterator1, class Iterator2>
-	friend bool
-	operator>=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
-	{
-		return (lhs.base() >= rhs.base());
-	}
 };
+
+/* ------------------------ Non-member functions ------------------------ */
+template <class Iterator1, class Iterator2>
+bool operator==(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
+{
+	return (lhs.base() == rhs.base());
+}
+template <class Iterator1, class Iterator2>
+bool operator!=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
+{
+	return (lhs.base() != rhs.base());
+}
+template <class Iterator1, class Iterator2>
+bool operator<(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
+{
+	return (lhs.base() < rhs.base());
+}
+template <class Iterator1, class Iterator2>
+bool operator<=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
+{
+	return (lhs.base() <= rhs.base());
+}
+template <class Iterator1, class Iterator2>
+bool operator>(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
+{
+	return (lhs.base() > rhs.base());
+}
+template <class Iterator1, class Iterator2>
+bool operator>=(const reverse_iterator<Iterator1>& lhs, const reverse_iterator<Iterator2>& rhs)
+{
+	return (lhs.base() >= rhs.base());
+}
 
 } // namespace ft
 

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -376,10 +376,13 @@ void vector<T, Allocator>::resize(size_type count, T value)
 template <class T, class Allocator>
 void vector<T, Allocator>::swap(vector& other)
 {
-	vector<T, Allocator> save = *this;
+	std::swap(_begin, other._begin);
+	std::swap(_end, other._end);
+	std::swap(_end_cap, other._end_cap);
 
-	*this = other;
-	other = save;
+	Allocator save_alloc = _alloc;
+	_alloc               = other._alloc;
+	other._alloc         = save_alloc;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -55,7 +55,8 @@ class vector
 	// assign
 	void assign(size_type count, const T& value);
 	template <class InputIt>
-	void assign(InputIt first, InputIt last);
+	void assign(InputIt first, InputIt last,
+	    typename ft::enable_if<!ft::is_integral<InputIt>::value>::type* = 0);
 	// get_allocator
 	allocator_type get_allocator() const { return _alloc; }
 	// --------------------------- Elements access -------------------------- //
@@ -185,7 +186,8 @@ void vector<T, Allocator>::assign(size_type count, const T& value)
 
 template <class T, class Allocator>
 template <class InputIt>
-void vector<T, Allocator>::assign(InputIt first, InputIt last)
+void vector<T, Allocator>::assign(
+    InputIt first, InputIt last, typename ft::enable_if<!ft::is_integral<InputIt>::value>::type*)
 {
 	size_type count = static_cast<size_type>(last - first);
 	pointer   current;

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -23,10 +23,10 @@ class vector
 	typedef typename Allocator::pointer       pointer;
 	typedef typename Allocator::const_pointer const_pointer;
 
-	typedef random_access_iterator<T>            iterator;
-	typedef random_access_iterator<T>            const_iterator;
-	typedef ft::reverse_iterator<iterator>       reverse_iterator;
-	typedef ft::reverse_iterator<const_iterator> const_reverse_iterator;
+	typedef random_access_iterator<value_type>       iterator;
+	typedef random_access_iterator<const value_type> const_iterator;
+	typedef ft::reverse_iterator<iterator>           reverse_iterator;
+	typedef ft::reverse_iterator<const_iterator>     const_reverse_iterator;
 
   private:
 	pointer        _begin;

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -39,7 +39,8 @@ class vector
 	explicit vector(const Allocator& alloc);
 	explicit vector(size_type count, const T& value = T(), const Allocator& alloc = Allocator());
 	template <class InputIt>
-	vector(InputIt first, InputIt last, const Allocator& alloc = Allocator());
+	vector(InputIt first, InputIt last, const Allocator& alloc = Allocator(),
+	    typename ft::enable_if<!ft::is_integral<InputIt>::value>::type* = 0);
 	vector(const vector& other);
 	// (destructor)
 	~vector()
@@ -135,7 +136,9 @@ vector<T, Allocator>::vector(size_type count, const T& value, const Allocator& a
 
 template <class T, class Allocator>
 template <class InputIt>
-vector<T, Allocator>::vector(InputIt first, InputIt last, const Allocator& alloc) : _alloc(alloc)
+vector<T, Allocator>::vector(InputIt first, InputIt last, const Allocator& alloc,
+    typename ft::enable_if<!ft::is_integral<InputIt>::value>::type*) :
+    _alloc(alloc)
 {
 	size_type count = static_cast<size_type>(last - first);
 	_vallocate(count);

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -140,7 +140,7 @@ vector<T, Allocator>::vector(InputIt first, InputIt last, const Allocator& alloc
     typename ft::enable_if<!ft::is_integral<InputIt>::value>::type*) :
     _alloc(alloc)
 {
-	size_type count = static_cast<size_type>(last - first);
+	size_type count = std::distance(first, last);
 	_vallocate(count);
 	_construct_at_end(count);
 	std::copy(first, last, _begin);
@@ -192,7 +192,7 @@ template <class InputIt>
 void vector<T, Allocator>::assign(
     InputIt first, InputIt last, typename ft::enable_if<!ft::is_integral<InputIt>::value>::type*)
 {
-	size_type count = static_cast<size_type>(last - first);
+	size_type count = std::distance(first, last);
 	pointer   current;
 
 	if (capacity() < count)
@@ -297,7 +297,7 @@ template <class InputIt>
 void vector<T, Allocator>::insert(iterator pos, InputIt first, InputIt last,
     typename ft::enable_if<!ft::is_integral<InputIt>::value>::type*)
 {
-	difference_type count  = last - first;
+	difference_type count  = std::distance(first, last);
 	difference_type offset = pos - begin();
 
 	if (size() + count >= capacity()) {

--- a/includes/vector.hpp
+++ b/includes/vector.hpp
@@ -131,7 +131,7 @@ vector<T, Allocator>::vector(size_type count, const T& value, const Allocator& a
     _alloc(alloc)
 {
 	_vallocate(count);
-	assign(count, value);
+	_construct_at_end(count, value);
 }
 
 template <class T, class Allocator>


### PR DESCRIPTION
- close #34
- fix: add enable_if for assign()
- add: operator[]
- add: enable_if for constructor
- fix: operator+
- add: operator+= / -=
- fix: return type to reverse_iterator
- fix: operator[] return type
- add: operator+ / - for reverse_iterator
- fix: delete std:: from non-member overloads; reverse_iterator
- fix: add const qualifiers to operator* / ->
- fix: typedef add const
- fix: drop friend from non-member funcs; reverse_iterator
- add: iterator_type & base()
- update
- update: delete friend from comparison operators
- fix: delete friend from oprtator+/- overloads
- fix: delete friend from oprtator+/- overloads; reverse_iterator
- fix: template constructors to use base()
- fix: operator->()
- fix: constructor call _construct_at_end instead of assign()
- fix: swap to save iterator validity
- fix: operator+ / - to const
- fix: operator[] ; wrong result on rite2.cpp
- fix: reverse operation +/- for operator+/-
- fix: use std::distance for iterator distance
- fix: returning reveresed resultis; reverse_operator
- refactor: rewirte comparison operators using base(); random_access_iterator
- refactor: use typename iterator_type
