### PR TITLE
feat/#44RBtree implementation

### DIFF
--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -23,11 +23,6 @@ class map
 	typedef typename Allocator::pointer       pointer;
 	typedef typename Allocator::const_pointer const_pointer;
 
-	typedef ft::random_access_iterator<value_type>       iterator;
-	typedef ft::random_access_iterator<const value_type> const_iterator;
-	typedef ft::reverse_iterator<iterator>               reverse_iterator;
-	typedef ft::reverse_iterator<const_iterator>         const_reverse_iterator;
-
 	class value_compare
 	{
 	  public:
@@ -49,6 +44,11 @@ class map
 	_base _tree;
 
   public:
+	typedef typename _base::iterator             iterator;
+	typedef typename _base::const_iterator       const_iterator;
+	typedef ft::reverse_iterator<iterator>       reverse_iterator;
+	typedef ft::reverse_iterator<const_iterator> const_reverse_iterator;
+
 	// (constructor)
 	map(){};
 	explicit map(const Compare& comp, const Allocator& alloc = Allocator()){};

--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -2,6 +2,7 @@
 #define MAP_HPP
 
 #include "iterators.hpp"
+#include "rbtree.hpp"
 
 namespace ft {
 
@@ -43,7 +44,9 @@ class map
 	};
 
   private:
-	// _base _tree;
+	typedef _rbtree<value_type, key_compare, allocator_type> _base;
+
+	_base _tree;
 
   public:
 	// (constructor)

--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -67,14 +67,14 @@ class map
 	// operator[]
 	T& operator[](const Key& key){};
 	// ------------------------------- Iterators ------------------------------- //
-	iterator               begin(){};
-	const_iterator         begin() const {};
-	iterator               end(){};
-	const_iterator         end() const {};
-	reverse_iterator       rbegin(){};
-	const_reverse_iterator rbegin() const {};
-	reverse_iterator       rend(){};
-	const_reverse_iterator rend() const {};
+	iterator               begin() { return _tree.begin(); }
+	const_iterator         begin() const { return _tree.begin(); }
+	iterator               end() { return _tree.end(); }
+	const_iterator         end() const { return _tree.end(); }
+	reverse_iterator       rbegin() { return reverse_iterator(end()); }
+	const_reverse_iterator rbegin() const { return reverse_iterator(end()); }
+	reverse_iterator       rend() { return reverse_iterator(begin()); }
+	const_reverse_iterator rend() const { return reverse_iterator(begin()); }
 	/* -------------------------------- Capacity ------------------------------- */
 	bool      empty() const {};
 	size_type size() const {};

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -40,6 +40,36 @@ class _tree_node
 	_tree_node(_tree_node const& other);
 };
 
+template <class T>
+class _rbtree_iterator
+{
+  public:
+	typedef std::bidirectional_iterator_tag iterator_category;
+	typedef T                               value_type;
+	typedef value_type&                     reference;
+	typedef value_type*                     pointer;
+
+  private:
+	pointer _ptr_;
+	pointer _nil_node_;
+
+  public:
+	_rbtree_iterator() : _ptr_(NULL) {}
+	reference operator*() const;
+	pointer   operator->() const;
+
+	_rbtree_iterator& operator++();
+	_rbtree_iterator  operator++(int);
+	_rbtree_iterator& operator--();
+	_rbtree_iterator  operator--(int);
+
+	friend bool operator==(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
+	{
+		return _x._ptr_ == _y._ptr_;
+	}
+	bool operator!=(const _rbtree_iterator& _x, const _rbtree_iterator& _y) { return !(_x == _y) }
+};
+
 template <class T, class Comp, class Allocator>
 class _rbtree
 {

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -55,6 +55,9 @@ class _rbtree
 
   private:
 	node_pointer _init_tree_node(node_value_type v);
+
+	void _rotate_left(node_pointer ptr);
+	void _rotate_right(node_pointer ptr);
 	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
 	node_pointer& _find_parent(node_pointer p);
 
@@ -63,6 +66,53 @@ class _rbtree
 	void display();
 };
 
+/* -------------------------------------------------------------------------- */
+/*                                   rotates                                  */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_rotate_left(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+{
+	node_pointer child = ptr->_right;
+	ptr->_right        = child->_left;
+	if (ptr->_right != _nil_node) {
+		ptr->_right->parent = ptr;
+	}
+
+	node_pointer parent = ptr->_parent;
+	child->_parent      = parent;
+	if (parent == _nil_node) {
+		_begin_node = child;
+	} else if (ptr == parent->_left) {
+		parent->_left = child;
+	} else {
+		parent->_right = child;
+	}
+	child->_left = ptr;
+	ptr->_parent = child;
+}
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+{
+	node_pointer child = ptr->_left;
+	ptr->_left         = child->_right;
+	if (ptr->_right != _nil_node) {
+		ptr->_right->parent = ptr;
+	}
+
+	node_pointer parent = ptr->_parent;
+	child->_parent      = parent;
+	if (parent == _nil_node) {
+		_begin_node = child;
+	} else if (ptr == parent->_left) {
+		parent->_left = child;
+	} else {
+		parent->_right = child;
+	}
+	child->_right = ptr;
+	ptr->_parent  = child;
+}
 
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -46,13 +46,15 @@ class _rbtree
   public:
 	_rbtree()
 	{
-		_nil_node   = new node_type;
+		_nil_node   = _allocate_tree_node(0);
 		_begin_node = _nil_node;
 	};
 	~_rbtree(){};
 	_rbtree(_rbtree const& other);
 	_rbtree& operator=(_rbtree const& other);
 
+  private:
+	node_pointer _allocate_tree_node(node_value_type v);
 	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
 	node_pointer& _find_parent(node_pointer p);
 
@@ -65,7 +67,7 @@ class _rbtree
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
 {
-	node_pointer new_   = new node_type;
+	node_pointer new_   = _allocate_tree_node(value);
 	node_pointer parent = _nil_node;
 
 	for (node_pointer current = _begin_node; current != _nil_node;) {
@@ -83,11 +85,25 @@ void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node
 	} else {
 		parent->_right = new_;
 	}
-	new_->_parent   = parent;
-	new_->_right    = _nil_node;
-	new_->_left     = _nil_node;
-	new_->_value    = value;
-	new_->_is_black = false;
+	new_->_parent = parent;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              private functions                             */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+typename _rbtree<T, Comp, Allocator>::node_pointer
+_rbtree<T, Comp, Allocator>::_allocate_tree_node(_rbtree<T, Comp, Allocator>::node_value_type v)
+{
+	node_pointer ptr = new node_type;
+	ptr->_parent     = _nil_node;
+	ptr->_right      = _nil_node;
+	ptr->_left       = _nil_node;
+	ptr->_value      = v;
+	ptr->_is_black   = false;
+
+	return ptr;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -27,7 +27,7 @@ class _tree_node
 	value_type _value;
 	bool       _is_black;
 
-	_tree_node() : _parent(NULL), _right(NULL), _left(NULL), _value(0), _is_black(false){};
+	_tree_node() : _parent(NULL), _right(NULL), _left(NULL), _is_black(false){};
 	_tree_node& operator=(_tree_node const& other)
 	{
 		if (*this != other) {
@@ -250,7 +250,6 @@ _rbtree<T, Comp, Allocator>::_rbtree()
 	_nil_node->_parent   = _nil_node;
 	_nil_node->_left     = _nil_node;
 	_nil_node->_right    = _nil_node;
-	_nil_node->_value    = 0;
 	_begin_node          = _nil_node;
 }
 

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -187,6 +187,8 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 				ptr->_parent->_is_black   = true;
 				uncle->_is_black          = true;
 				uncle->_parent->_is_black = false;
+
+				ptr = uncle->_parent;
 			} else {
 				if (_is_right_child(ptr)) {
 					ptr = ptr->_parent;
@@ -202,6 +204,8 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 				ptr->_parent->_is_black   = true;
 				uncle->_is_black          = true;
 				uncle->_parent->_is_black = false;
+
+				ptr = uncle->_parent;
 			} else {
 				if (_is_left_child(ptr)) {
 					ptr = ptr->_parent;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -62,20 +62,20 @@ class _rbtree
 	_rbtree(_rbtree const& other);
 	_rbtree& operator=(_rbtree const& other);
 
-	node_pointer _find(const node_value_type& v) const;
-	node_pointer insert(const node_value_type& v);
-	node_pointer _delete(const node_value_type& v);
+	node_pointer _find(const node_value_type& value) const;
+	node_pointer insert(const node_value_type& value);
+	node_pointer _delete(const node_value_type& value);
 	void         display(std::string func_name = "", int line = -1) const;
 
   private:
-	node_pointer _init_tree_node(node_value_type v);
+	node_pointer _init_tree_node(node_value_type value);
 
 	/* ------------------------------- algorithms ------------------------------ */
-	node_pointer _find_recursive(const node_pointer ptr, const node_value_type& v) const;
-	void         _transplant(node_pointer old_, node_pointer new_);
+	node_pointer _find_recursive(const node_pointer ptr, const node_value_type& value) const;
+	void         _transplant(node_pointer old_ptr, node_pointer new_ptr);
 	void         _rotate_left(node_pointer ptr);
 	void         _rotate_right(node_pointer ptr);
-	void         _insert_fixup(node_pointer v);
+	void         _insert_fixup(node_pointer otr);
 	void         _delete_fixup(node_pointer ptr);
 
 	/* --------------------------------- utils --------------------------------- */
@@ -89,7 +89,7 @@ class _rbtree
 	/* --------------------------------- debug --------------------------------- */
 	int         _check_tree_recursive(node_pointer ptr, int black_count, int& invalid) const;
 	void        _check_tree_validity() const;
-	std::string _node_to_dir(const node_pointer& v, std::string dirprefix, bool is_right) const;
+	std::string _node_to_dir(const node_pointer& value, std::string dirprefix, bool is_right) const;
 };
 
 /* -------------------------------------------------------------------------- */
@@ -187,13 +187,13 @@ _rbtree<T, Comp, Allocator>::_delete(const _rbtree<T, Comp, Allocator>::node_val
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_init_tree_node(_rbtree<T, Comp, Allocator>::node_value_type v)
+_rbtree<T, Comp, Allocator>::_init_tree_node(_rbtree<T, Comp, Allocator>::node_value_type value)
 {
 	node_pointer ptr = new node_type;
 	ptr->_parent     = _nil_node;
 	ptr->_right      = _nil_node;
 	ptr->_left       = _nil_node;
-	ptr->_value      = v;
+	ptr->_value      = value;
 	ptr->_is_black   = false;
 
 	return ptr;
@@ -209,7 +209,7 @@ _rbtree<T, Comp, Allocator>::_find_recursive(const _rbtree<T, Comp, Allocator>::
     const _rbtree<T, Comp, Allocator>::node_value_type& value) const
 {
 	node_pointer found;
-	// node
+
 	if (ptr == _nil_node) {
 		return NULL;
 	} else if (ptr->_value == value) {
@@ -225,17 +225,17 @@ _rbtree<T, Comp, Allocator>::_find_recursive(const _rbtree<T, Comp, Allocator>::
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_transplant(
-    _rbtree<T, Comp, Allocator>::node_pointer old_, _rbtree<T, Comp, Allocator>::node_pointer new_)
+void _rbtree<T, Comp, Allocator>::_transplant(_rbtree<T, Comp, Allocator>::node_pointer old_ptr,
+    _rbtree<T, Comp, Allocator>::node_pointer                                           new_ptr)
 {
-	if (old_->_parent == _nil_node) {
-		_begin_node = new_;
-	} else if (_is_left_child(old_)) {
-		old_->_parent->_left = new_;
+	if (old_ptr->_parent == _nil_node) {
+		_begin_node = new_ptr;
+	} else if (_is_left_child(old_ptr)) {
+		old_ptr->_parent->_left = new_ptr;
 	} else {
-		old_->_parent->_right = new_;
+		old_ptr->_parent->_right = new_ptr;
 	}
-	new_->_parent = old_->_parent;
+	new_ptr->_parent = old_ptr->_parent;
 }
 
 template <class T, class Comp, class Allocator>

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -98,11 +98,11 @@ class _rbtree_iterator
 	typedef value_type*                     pointer;
 
   private:
-	pointer _ptr_;
-	pointer _nil_node_;
+	pointer _curret_;
+	pointer _nil_;
 
   public:
-	_rbtree_iterator() : _ptr_(NULL) {}
+	_rbtree_iterator() : _curret_(NULL) {}
 	reference operator*() const;
 	pointer   operator->() const;
 
@@ -113,7 +113,7 @@ class _rbtree_iterator
 
 	friend bool operator==(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
 	{
-		return _x._ptr_ == _y._ptr_;
+		return _x._curret_ == _y._curret_;
 	}
 	friend bool operator!=(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
 	{

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -89,7 +89,10 @@ class _rbtree
 	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
 	node_pointer& _find_parent(node_pointer p);
 
+	node_pointer _find_recursive(const node_pointer ptr, const node_value_type& v) const;
+
   public:
+	node_pointer _find(const node_value_type& v) const;
 	node_pointer insert(const node_value_type& v);
 	void         display(std::string func_name = "", int line = -1);
 };
@@ -122,6 +125,38 @@ template <class T, class Comp, class Allocator>
 bool _rbtree<T, Comp, Allocator>::_is_red(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	return (!ptr->_is_black);
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                    find                                    */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+typename _rbtree<T, Comp, Allocator>::node_pointer
+_rbtree<T, Comp, Allocator>::_find_recursive(const _rbtree<T, Comp, Allocator>::node_pointer ptr,
+    const _rbtree<T, Comp, Allocator>::node_value_type& value) const
+{
+	node_pointer found;
+	// node
+	if (ptr == _nil_node) {
+		return NULL;
+	} else if (ptr->_value == value) {
+		return ptr;
+	}
+
+	found = _find_recursive(ptr->_right, value);
+	if (found) {
+		return found;
+	}
+	found = _find_recursive(ptr->_left, value);
+	return found;
+}
+
+template <class T, class Comp, class Allocator>
+typename _rbtree<T, Comp, Allocator>::node_pointer
+_rbtree<T, Comp, Allocator>::_find(const _rbtree<T, Comp, Allocator>::node_value_type& value) const
+{
+	return _find_recursive(_begin_node, value);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -280,6 +280,10 @@ void _rbtree<T, Comp, Allocator>::display(std::string func_name, int line)
 	dirpath = _node_to_dir(_begin_node, "./", true);
 
 	std::cout << __FILE__ << ":" << line << " (" << func_name << ")" << std::endl;
+	if (dirpath == "") {
+		std::cerr << "Error: root deleted" << std::endl;
+		exit(1);
+	}
 
 	setenv("LS_COLORS", "di=00;91:ow=30;107", 1); /* set Red & Black color */
 	cmd = "tree -C --noreport " + dirpath;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -1,6 +1,7 @@
 #ifndef RBTREE_HPP
 #define RBTREE_HPP
 
+#include "type_traits.hpp"
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -39,6 +40,53 @@ class _tree_node
   private:
 	_tree_node(_tree_node const& other);
 };
+
+namespace {
+
+/* -------------------------------------------------------------------------- */
+/*                                    utils                                   */
+/* -------------------------------------------------------------------------- */
+
+template <class _NodePtr>
+bool _is_left_child_(const _NodePtr ptr)
+{
+	return (ptr == ptr->_parent->_left);
+}
+
+template <class _NodePtr>
+bool _is_right_child_(const _NodePtr ptr)
+{
+	return (ptr == ptr->_parent->_right);
+}
+
+template <class _NodePtr>
+bool _is_black_(
+    const _NodePtr ptr, typename ft::enable_if<!ft::is_integral<_NodePtr>::value>::type* = 0)
+{
+	return (ptr->_is_black);
+}
+
+bool _is_black_(bool _is_black_)
+{
+	return (_is_black_);
+}
+
+template <class _NodePtr>
+bool _is_red_(const _NodePtr ptr)
+{
+	return (!ptr->_is_black);
+}
+
+template <class _NodePtr>
+_NodePtr _tree_min_(_NodePtr ptr, _NodePtr _nil_node)
+{
+	while (ptr->_left != _nil_node) {
+		ptr = ptr->_left;
+	}
+	return ptr;
+}
+
+} // namespace
 
 template <class T>
 class _rbtree_iterator
@@ -110,14 +158,6 @@ class _rbtree
 	void         _rotate_right_(node_pointer ptr);
 	void         _insert_fixup_(node_pointer ptr);
 	void         _delete_fixup_(node_pointer ptr);
-
-	/* --------------------------------- utils --------------------------------- */
-	bool         _is_left_child_(const node_pointer ptr) const;
-	bool         _is_right_child_(const node_pointer ptr) const;
-	bool         _is_black_(const node_pointer ptr) const;
-	bool         _is_black_(bool _is_black_) const;
-	bool         _is_red_(const node_pointer ptr) const;
-	node_pointer _tree_min_(node_pointer ptr) const;
 
 	/* --------------------------------- debug --------------------------------- */
 	int  _check_tree_recursive_(node_pointer ptr, int black_count, int& invalid) const;
@@ -217,7 +257,7 @@ _rbtree<T, Comp, Allocator>::_delete(const _rbtree<T, Comp, Allocator>::value_ty
 		child_to_recolor = ptr->_left;
 		_transplant_(ptr, ptr->_left);
 	} else {
-		fix_trigger_node = _tree_min_(ptr->_right);
+		fix_trigger_node = _tree_min_(ptr->_right, _nil_node);
 		original_color   = _is_black_(fix_trigger_node);
 		child_to_recolor = fix_trigger_node->_right;
 		if (fix_trigger_node->_parent == ptr) {
@@ -442,54 +482,6 @@ void _rbtree<T, Comp, Allocator>::_delete_fixup_(
 		}
 	}
 	ptr->_is_black = true;
-}
-
-/* -------------------------------------------------------------------------- */
-/*                                    utils                                   */
-/* -------------------------------------------------------------------------- */
-
-template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_left_child_(
-    const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
-{
-	return (ptr == ptr->_parent->_left);
-}
-
-template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_right_child_(
-    const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
-{
-	return (ptr == ptr->_parent->_right);
-}
-
-template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_black_(
-    const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
-{
-	return (ptr->_is_black);
-}
-
-template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_black_(bool _is_black_) const
-{
-	return (_is_black_);
-}
-
-template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_red_(
-    const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
-{
-	return (!ptr->_is_black);
-}
-
-template <class T, class Comp, class Allocator>
-typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_tree_min_(_rbtree<T, Comp, Allocator>::node_pointer ptr) const
-{
-	while (ptr->_left != _nil_node) {
-		ptr = ptr->_left;
-	}
-	return ptr;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -169,11 +169,11 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 			} else {
 				if (!_is_left_child(ptr)) {
 					ptr = ptr->_parent;
-					_rotate_right(ptr);
+					_rotate_left(ptr);
 				}
 				ptr->_parent->_is_black          = true;
 				ptr->_parent->_parent->_is_black = false;
-				_rotate_left(ptr->_parent);
+				_rotate_right(ptr->_parent->_parent);
 			}
 		} else {
 			uncle = ptr->_parent->_parent->_left;
@@ -184,11 +184,11 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 			} else {
 				if (_is_left_child(ptr)) {
 					ptr = ptr->_parent;
-					_rotate_left(ptr);
+					_rotate_right(ptr);
 				}
 				ptr->_parent->_is_black          = true;
 				ptr->_parent->_parent->_is_black = false;
-				_rotate_right(ptr->_parent);
+				_rotate_left(ptr->_parent->_parent);
 			}
 		}
 	}

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -75,7 +75,7 @@ class _rbtree
 	void         _transplant(node_pointer old_ptr, node_pointer new_ptr);
 	void         _rotate_left(node_pointer ptr);
 	void         _rotate_right(node_pointer ptr);
-	void         _insert_fixup(node_pointer otr);
+	void         _insert_fixup(node_pointer ptr);
 	void         _delete_fixup(node_pointer ptr);
 
 	/* --------------------------------- utils --------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -131,15 +131,16 @@ class _rbtree_iterator
 	typedef value_type*                     pointer;
 
   private:
-	pointer _curret_;
+	pointer _current_;
 	pointer _nil_;
 
   public:
-	_rbtree_iterator() : _curret_(NULL), _nil_(NULL) {}
-	_rbtree_iterator(pointer current, pointer nil) : _curret_(current), _nil_(nil) {}
-	reference operator*() const { return _curret_->_value; }
-	pointer   operator->() const { return _curret_; }
+	_rbtree_iterator() : _current_(NULL), _nil_(NULL) {}
+	_rbtree_iterator(pointer current, pointer nil) : _current_(current), _nil_(nil) {}
 
+	reference operator*() const { return _current_->_value; }
+	pointer   operator->() const { return _current_; }
+	/* ------------------------ Arithmetic operators ------------------------ */
 	_rbtree_iterator& operator++()
 	{
 		_current_ = _tree_next_(_current_, _nil_);
@@ -162,7 +163,7 @@ class _rbtree_iterator
 		--(*this);
 		return _tmp;
 	}
-
+	/* ------------------------ Non-member functions ------------------------ */
 	friend bool operator==(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
 	{
 		return _x._curret_ == _y._curret_;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -79,6 +79,8 @@ class _rbtree
 	bool _is_black(node_pointer ptr);
 	bool _is_red(node_pointer ptr);
 
+	void _transplant(node_pointer old_, node_pointer new_);
+
 	void _rotate_left(node_pointer ptr);
 	void _rotate_right(node_pointer ptr);
 
@@ -120,6 +122,24 @@ template <class T, class Comp, class Allocator>
 bool _rbtree<T, Comp, Allocator>::_is_red(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	return (!ptr->_is_black);
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                 transplant                                 */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_transplant(
+    _rbtree<T, Comp, Allocator>::node_pointer old_, _rbtree<T, Comp, Allocator>::node_pointer new_)
+{
+	if (old_->_parent == _nid_node) {
+		_begin_node = new_;
+	} else if (_is_left_child(old_)) {
+		old_->_parent->_left = new_;
+	} else {
+		old_->_parent->_right = new_;
+	}
+	new_->_parent = old_->_parent;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -69,6 +69,7 @@ class _rbtree
 
   public:
 	node_pointer insert(const node_value_type& v);
+	void         display(std::string func_name = "", int line = -1);
 };
 
 
@@ -258,14 +259,16 @@ std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::display()
+void _rbtree<T, Comp, Allocator>::display(std::string func_name, int line)
 {
 	std::string dirpath;
 	std::string cmd;
 	dirpath = _node_to_dir(_begin_node, "./", true);
 
+	std::cout << __FILE__ << ":" << line << " (" << func_name << ")" << std::endl;
+
 	setenv("LS_COLORS", "di=00;91:ow=30;107", 1); /* set Red & Black color */
-	cmd = "tree -C " + dirpath;
+	cmd = "tree -C --noreport " + dirpath;
 	system(cmd.c_str());
 	cmd = "rm -Rf " + dirpath;
 	system(cmd.c_str());

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -109,6 +109,30 @@ _rbtree<T, Comp, Allocator>::_rbtree()
 }
 
 template <class T, class Comp, class Allocator>
+_rbtree<T, Comp, Allocator>::_rbtree(_rbtree<T, Comp, Allocator> const& other)
+{
+	_nil_node   = new node_type;
+	_nil_node   = other._nil_node;
+	_begin_node = other._begin_node;
+	_alloc      = other._alloc;
+	_comp       = other._comp;
+}
+
+template <class T, class Comp, class Allocator>
+_rbtree<T, Comp, Allocator>&
+_rbtree<T, Comp, Allocator>::operator=(_rbtree<T, Comp, Allocator> const& other)
+{
+	if (this != &other) {
+		_nil_node   = new node_type;
+		_nil_node   = other._nil_node;
+		_begin_node = other._begin_node;
+		_alloc      = other._alloc;
+		_comp       = other._comp;
+	}
+	return *this;
+}
+
+template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
 {

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -146,17 +146,18 @@ void _rbtree<T, Comp, Allocator>::_rotate_left(const _rbtree<T, Comp, Allocator>
 	}
 	child->_left = ptr;
 	ptr->_parent = child;
+	display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
+	display(__FUNCTION__, __LINE__);
 	node_pointer child = ptr->_left;
 	ptr->_left         = child->_right;
 	if (ptr->_right != _nil_node) {
 		ptr->_right->_parent = ptr;
 	}
-
 	node_pointer parent = ptr->_parent;
 	child->_parent      = parent;
 	if (parent == _nil_node) {
@@ -168,6 +169,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator
 	}
 	child->_right = ptr;
 	ptr->_parent  = child;
+	display(__FUNCTION__, __LINE__);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -212,6 +214,7 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 		}
 	}
 	_begin_node->_is_black = true;
+	display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
@@ -237,6 +240,7 @@ _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_valu
 		parent->_right = new_;
 	}
 	new_->_parent = parent;
+	display(__FUNCTION__, __LINE__);
 	_insert_fixup(new_);
 	return new_;
 }

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -68,28 +68,29 @@ class _rbtree
 	void         _display(std::string func_name = "", int line = -1) const;
 
   private:
-	node_pointer _init_tree_node(node_value_type value);
+	node_pointer _init_tree_node_(node_value_type value);
 
 	/* ------------------------------- algorithms ------------------------------ */
-	node_pointer _find_recursive(const node_pointer ptr, const node_value_type& value) const;
-	void         _transplant(node_pointer old_ptr, node_pointer new_ptr);
-	void         _rotate_left(node_pointer ptr);
-	void         _rotate_right(node_pointer ptr);
-	void         _insert_fixup(node_pointer ptr);
-	void         _delete_fixup(node_pointer ptr);
+	node_pointer _find_recursive_(const node_pointer ptr, const node_value_type& value) const;
+	void         _transplant_(node_pointer old_ptr, node_pointer new_ptr);
+	void         _rotate_left_(node_pointer ptr);
+	void         _rotate_right_(node_pointer ptr);
+	void         _insert_fixup_(node_pointer ptr);
+	void         _delete_fixup_(node_pointer ptr);
 
 	/* --------------------------------- utils --------------------------------- */
-	bool         _is_left_child(const node_pointer ptr) const;
-	bool         _is_right_child(const node_pointer ptr) const;
-	bool         _is_black(const node_pointer ptr) const;
-	bool         _is_black(bool _is_black_) const;
-	bool         _is_red(const node_pointer ptr) const;
-	node_pointer _tree_min(node_pointer ptr) const;
+	bool         _is_left_child_(const node_pointer ptr) const;
+	bool         _is_right_child_(const node_pointer ptr) const;
+	bool         _is_black_(const node_pointer ptr) const;
+	bool         _is_black_(bool _is_black_) const;
+	bool         _is_red_(const node_pointer ptr) const;
+	node_pointer _tree_min_(node_pointer ptr) const;
 
 	/* --------------------------------- debug --------------------------------- */
-	int         _check_tree_recursive(node_pointer ptr, int black_count, int& invalid) const;
-	void        _check_tree_validity() const;
-	std::string _node_to_dir(const node_pointer& value, std::string dirprefix, bool is_right) const;
+	int  _check_tree_recursive_(node_pointer ptr, int black_count, int& invalid) const;
+	void _check_tree_validity_() const;
+	std::string
+	_node_to_dir_(const node_pointer& value, std::string dirprefix, bool is_right) const;
 };
 
 /* -------------------------------------------------------------------------- */
@@ -136,7 +137,7 @@ template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::_insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
 {
-	node_pointer new_   = _init_tree_node(value);
+	node_pointer new_   = _init_tree_node_(value);
 	node_pointer parent = _nil_node;
 
 	for (node_pointer current = _begin_node; current != _nil_node;) {
@@ -156,7 +157,7 @@ _rbtree<T, Comp, Allocator>::_insert(const _rbtree<T, Comp, Allocator>::node_val
 	}
 	new_->_parent = parent;
 	_display(__FUNCTION__, __LINE__);
-	_insert_fixup(new_);
+	_insert_fixup_(new_);
 	return new_;
 }
 
@@ -164,7 +165,7 @@ template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::_find(const _rbtree<T, Comp, Allocator>::node_value_type& value) const
 {
-	return _find_recursive(_begin_node, value);
+	return _find_recursive_(_begin_node, value);
 }
 
 template <class T, class Comp, class Allocator>
@@ -174,33 +175,33 @@ _rbtree<T, Comp, Allocator>::_delete(const _rbtree<T, Comp, Allocator>::node_val
 	node_pointer ptr              = _find(value);
 	node_pointer fix_trigger_node = ptr;
 	node_pointer child_to_recolor;
-	bool         original_color = _is_black(fix_trigger_node);
+	bool         original_color = _is_black_(fix_trigger_node);
 
 	if (ptr->_left == _nil_node) {
 		child_to_recolor = ptr->_right;
-		_transplant(ptr, ptr->_right);
+		_transplant_(ptr, ptr->_right);
 	} else if (ptr->_right == _nil_node) {
 		child_to_recolor = ptr->_left;
-		_transplant(ptr, ptr->_left);
+		_transplant_(ptr, ptr->_left);
 	} else {
-		fix_trigger_node = _tree_min(ptr->_right);
-		original_color   = _is_black(fix_trigger_node);
+		fix_trigger_node = _tree_min_(ptr->_right);
+		original_color   = _is_black_(fix_trigger_node);
 		child_to_recolor = fix_trigger_node->_right;
 		if (fix_trigger_node->_parent == ptr) {
 			child_to_recolor->_parent = fix_trigger_node;
 		} else {
-			_transplant(fix_trigger_node, fix_trigger_node->_right);
+			_transplant_(fix_trigger_node, fix_trigger_node->_right);
 			fix_trigger_node->_right          = ptr->_right;
 			fix_trigger_node->_right->_parent = fix_trigger_node;
 		}
-		_transplant(ptr, fix_trigger_node);
+		_transplant_(ptr, fix_trigger_node);
 		fix_trigger_node->_left          = ptr->_left;
 		fix_trigger_node->_left->_parent = fix_trigger_node;
 		fix_trigger_node->_is_black      = ptr->_is_black;
 	}
 
-	if (_is_black(original_color)) {
-		_delete_fixup(child_to_recolor);
+	if (_is_black_(original_color)) {
+		_delete_fixup_(child_to_recolor);
 	}
 	return ptr;
 }
@@ -211,7 +212,7 @@ _rbtree<T, Comp, Allocator>::_delete(const _rbtree<T, Comp, Allocator>::node_val
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_init_tree_node(_rbtree<T, Comp, Allocator>::node_value_type value)
+_rbtree<T, Comp, Allocator>::_init_tree_node_(_rbtree<T, Comp, Allocator>::node_value_type value)
 {
 	node_pointer ptr = new node_type;
 	ptr->_parent     = _nil_node;
@@ -229,7 +230,7 @@ _rbtree<T, Comp, Allocator>::_init_tree_node(_rbtree<T, Comp, Allocator>::node_v
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_find_recursive(const _rbtree<T, Comp, Allocator>::node_pointer ptr,
+_rbtree<T, Comp, Allocator>::_find_recursive_(const _rbtree<T, Comp, Allocator>::node_pointer ptr,
     const _rbtree<T, Comp, Allocator>::node_value_type& value) const
 {
 	node_pointer found;
@@ -240,21 +241,21 @@ _rbtree<T, Comp, Allocator>::_find_recursive(const _rbtree<T, Comp, Allocator>::
 		return ptr;
 	}
 
-	found = _find_recursive(ptr->_right, value);
+	found = _find_recursive_(ptr->_right, value);
 	if (found) {
 		return found;
 	}
-	found = _find_recursive(ptr->_left, value);
+	found = _find_recursive_(ptr->_left, value);
 	return found;
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_transplant(_rbtree<T, Comp, Allocator>::node_pointer old_ptr,
-    _rbtree<T, Comp, Allocator>::node_pointer                                           new_ptr)
+void _rbtree<T, Comp, Allocator>::_transplant_(_rbtree<T, Comp, Allocator>::node_pointer old_ptr,
+    _rbtree<T, Comp, Allocator>::node_pointer                                            new_ptr)
 {
 	if (old_ptr->_parent == _nil_node) {
 		_begin_node = new_ptr;
-	} else if (_is_left_child(old_ptr)) {
+	} else if (_is_left_child_(old_ptr)) {
 		old_ptr->_parent->_left = new_ptr;
 	} else {
 		old_ptr->_parent->_right = new_ptr;
@@ -263,7 +264,7 @@ void _rbtree<T, Comp, Allocator>::_transplant(_rbtree<T, Comp, Allocator>::node_
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_rotate_left(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_rotate_left_(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	node_pointer child = ptr->_right;
 	ptr->_right        = child->_left;
@@ -275,7 +276,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_left(const _rbtree<T, Comp, Allocator>
 	child->_parent      = parent;
 	if (parent == _nil_node) {
 		_begin_node = child;
-	} else if (_is_left_child(ptr)) {
+	} else if (_is_left_child_(ptr)) {
 		parent->_left = child;
 	} else {
 		parent->_right = child;
@@ -286,7 +287,8 @@ void _rbtree<T, Comp, Allocator>::_rotate_left(const _rbtree<T, Comp, Allocator>
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_rotate_right_(
+    const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	_display(__FUNCTION__, __LINE__);
 	node_pointer child = ptr->_left;
@@ -298,7 +300,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator
 	child->_parent      = parent;
 	if (parent == _nil_node) {
 		_begin_node = child;
-	} else if (_is_left_child(ptr)) {
+	} else if (_is_left_child_(ptr)) {
 		parent->_left = child;
 	} else {
 		parent->_right = child;
@@ -309,43 +311,43 @@ void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_insert_fixup_(_rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	node_pointer uncle;
-	while (_is_red(ptr->_parent)) {
-		if (_is_left_child(ptr->_parent)) {
+	while (_is_red_(ptr->_parent)) {
+		if (_is_left_child_(ptr->_parent)) {
 			uncle = ptr->_parent->_parent->_right;
-			if (_is_red(uncle)) {
+			if (_is_red_(uncle)) {
 				ptr->_parent->_is_black   = true;
 				uncle->_is_black          = true;
 				uncle->_parent->_is_black = false;
 
 				ptr = uncle->_parent;
 			} else {
-				if (_is_right_child(ptr)) {
+				if (_is_right_child_(ptr)) {
 					ptr = ptr->_parent;
-					_rotate_left(ptr);
+					_rotate_left_(ptr);
 				}
 				ptr->_parent->_is_black          = true;
 				ptr->_parent->_parent->_is_black = false;
-				_rotate_right(ptr->_parent->_parent);
+				_rotate_right_(ptr->_parent->_parent);
 			}
 		} else {
 			uncle = ptr->_parent->_parent->_left;
-			if (_is_red(uncle)) {
+			if (_is_red_(uncle)) {
 				ptr->_parent->_is_black   = true;
 				uncle->_is_black          = true;
 				uncle->_parent->_is_black = false;
 
 				ptr = uncle->_parent;
 			} else {
-				if (_is_left_child(ptr)) {
+				if (_is_left_child_(ptr)) {
 					ptr = ptr->_parent;
-					_rotate_right(ptr);
+					_rotate_right_(ptr);
 				}
 				ptr->_parent->_is_black          = true;
 				ptr->_parent->_parent->_is_black = false;
-				_rotate_left(ptr->_parent->_parent);
+				_rotate_left_(ptr->_parent->_parent);
 			}
 		}
 	}
@@ -354,54 +356,55 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_delete_fixup(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_delete_fixup_(
+    const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	node_pointer cousin;
 
-	while (ptr != _begin_node && _is_black(ptr)) {
-		if (_is_left_child(ptr)) {
+	while (ptr != _begin_node && _is_black_(ptr)) {
+		if (_is_left_child_(ptr)) {
 			cousin = ptr->_parent->_right;
-			if (_is_red(cousin)) {
+			if (_is_red_(cousin)) {
 				cousin->_is_black       = true;
 				ptr->_parent->_is_black = false;
-				_rotate_left(ptr->_parent);
+				_rotate_left_(ptr->_parent);
 				cousin = ptr->_parent->_right;
 			}
-			if (_is_black(cousin->_left) && _is_black(cousin->_right)) {
+			if (_is_black_(cousin->_left) && _is_black_(cousin->_right)) {
 				cousin->_is_black = false;
 				ptr               = ptr->_parent;
-			} else if (_is_black(cousin->_right)) {
+			} else if (_is_black_(cousin->_right)) {
 				cousin->_left->_is_black = true;
 				cousin->_is_black        = false;
-				_rotate_right(cousin);
+				_rotate_right_(cousin);
 				cousin = ptr->_parent->_right;
 			}
 			cousin->_is_black         = ptr->_parent->_is_black;
 			ptr->_parent->_is_black   = true;
 			cousin->_right->_is_black = true;
-			_rotate_left(ptr->_parent);
+			_rotate_left_(ptr->_parent);
 			ptr = _begin_node;
 		} else {
 			cousin = ptr->_parent->_left;
-			if (_is_red(cousin)) {
+			if (_is_red_(cousin)) {
 				cousin->_is_black       = true;
 				ptr->_parent->_is_black = false;
-				_rotate_left(ptr->_parent);
+				_rotate_left_(ptr->_parent);
 				cousin = ptr->_parent->_left;
 			}
-			if (_is_black(cousin->_right) && _is_black(cousin->_left)) {
+			if (_is_black_(cousin->_right) && _is_black_(cousin->_left)) {
 				cousin->_is_black = false;
 				ptr               = ptr->_parent;
-			} else if (_is_black(cousin->_left)) {
+			} else if (_is_black_(cousin->_left)) {
 				cousin->_right->_is_black = true;
 				cousin->_is_black         = false;
-				_rotate_left(cousin);
+				_rotate_left_(cousin);
 				cousin = ptr->_parent->_left;
 			}
 			cousin->_is_black        = ptr->_parent->_is_black;
 			ptr->_parent->_is_black  = true;
 			cousin->_left->_is_black = true;
-			_rotate_right(ptr->_parent);
+			_rotate_right_(ptr->_parent);
 			ptr = _begin_node;
 		}
 	}
@@ -413,41 +416,42 @@ void _rbtree<T, Comp, Allocator>::_delete_fixup(const _rbtree<T, Comp, Allocator
 /* -------------------------------------------------------------------------- */
 
 template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_left_child(
+bool _rbtree<T, Comp, Allocator>::_is_left_child_(
     const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	return (ptr == ptr->_parent->_left);
 }
 
 template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_right_child(
+bool _rbtree<T, Comp, Allocator>::_is_right_child_(
     const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	return (ptr == ptr->_parent->_right);
 }
 
 template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_black(
+bool _rbtree<T, Comp, Allocator>::_is_black_(
     const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	return (ptr->_is_black);
 }
 
 template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_black(bool _is_black_) const
+bool _rbtree<T, Comp, Allocator>::_is_black_(bool _is_black_) const
 {
 	return (_is_black_);
 }
 
 template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_red(const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
+bool _rbtree<T, Comp, Allocator>::_is_red_(
+    const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	return (!ptr->_is_black);
 }
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_tree_min(_rbtree<T, Comp, Allocator>::node_pointer ptr) const
+_rbtree<T, Comp, Allocator>::_tree_min_(_rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	while (ptr->_left != _nil_node) {
 		ptr = ptr->_left;
@@ -460,7 +464,7 @@ _rbtree<T, Comp, Allocator>::_tree_min(_rbtree<T, Comp, Allocator>::node_pointer
 /* -------------------------------------------------------------------------- */
 
 template <class T, class Comp, class Allocator>
-int _rbtree<T, Comp, Allocator>::_check_tree_recursive(
+int _rbtree<T, Comp, Allocator>::_check_tree_recursive_(
     _rbtree<T, Comp, Allocator>::node_pointer ptr, int black_counts, int& invalid) const
 {
 	if (ptr == _nil_node) {
@@ -469,13 +473,13 @@ int _rbtree<T, Comp, Allocator>::_check_tree_recursive(
 	if (ptr->_is_black) {
 		++black_counts;
 	}
-	if (_is_red(ptr) && (_is_red(ptr->_left) || _is_red(ptr->_right))) {
+	if (_is_red_(ptr) && (_is_red_(ptr->_left) || _is_red_(ptr->_right))) {
 		std::cerr << "4. the children of red must be black" << std::endl;
 		++invalid;
 	}
 	int total;
-	total = _check_tree_recursive(ptr->_right, black_counts, invalid);
-	if (total != _check_tree_recursive(ptr->_left, black_counts, invalid)) {
+	total = _check_tree_recursive_(ptr->_right, black_counts, invalid);
+	if (total != _check_tree_recursive_(ptr->_left, black_counts, invalid)) {
 		std::cerr << "5. count of black nodes must be the same" << std::endl;
 		++invalid;
 	}
@@ -483,15 +487,15 @@ int _rbtree<T, Comp, Allocator>::_check_tree_recursive(
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_check_tree_validity() const
+void _rbtree<T, Comp, Allocator>::_check_tree_validity_() const
 {
 	int invalid = 0;
-	if (_is_red(_begin_node)) {
+	if (_is_red_(_begin_node)) {
 		std::cerr << "2. root must be black" << std::endl;
 		++invalid;
 	}
 	node_pointer ptr = _begin_node;
-	_check_tree_recursive(ptr, 0, invalid);
+	_check_tree_recursive_(ptr, 0, invalid);
 	if (invalid) {
 		std::cerr << "\033[31m"
 		          << "ERROR: tree is wrong... ;("
@@ -505,7 +509,7 @@ void _rbtree<T, Comp, Allocator>::_check_tree_validity() const
 }
 
 template <class T, class Comp, class Allocator>
-std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
+std::string _rbtree<T, Comp, Allocator>::_node_to_dir_(
     const _rbtree<T, Comp, Allocator>::node_pointer& v, std::string dirprefix, bool is_right) const
 {
 	if (v == _nil_node)
@@ -526,8 +530,8 @@ std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
 	mkdir(dirprefix.c_str(), mode);
 	chmod(dirprefix.c_str(), mode);
 
-	_node_to_dir(v->_right, dirprefix + "/", true);
-	_node_to_dir(v->_left, dirprefix + "/", false);
+	_node_to_dir_(v->_right, dirprefix + "/", true);
+	_node_to_dir_(v->_left, dirprefix + "/", false);
 	return dirprefix;
 }
 
@@ -536,7 +540,7 @@ void _rbtree<T, Comp, Allocator>::_display(std::string func_name, int line) cons
 {
 	std::string dirpath;
 	std::string cmd;
-	dirpath = _node_to_dir(_begin_node, "./", true);
+	dirpath = _node_to_dir_(_begin_node, "./", true);
 
 	std::cout << __FILE__ << ":" << line << " (" << func_name << ")" << std::endl;
 	if (dirpath == "") {
@@ -549,7 +553,7 @@ void _rbtree<T, Comp, Allocator>::_display(std::string func_name, int line) cons
 	system(cmd.c_str());
 	cmd = "rm -Rf " + dirpath;
 	system(cmd.c_str());
-	_check_tree_validity();
+	_check_tree_validity_();
 }
 
 } // namespace ft

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -63,9 +63,9 @@ class _rbtree
 	_rbtree& operator=(_rbtree const& other);
 
 	node_pointer _find(const node_value_type& value) const;
-	node_pointer insert(const node_value_type& value);
+	node_pointer _insert(const node_value_type& value);
 	node_pointer _delete(const node_value_type& value);
-	void         display(std::string func_name = "", int line = -1) const;
+	void         _display(std::string func_name = "", int line = -1) const;
 
   private:
 	node_pointer _init_tree_node(node_value_type value);
@@ -134,7 +134,7 @@ _rbtree<T, Comp, Allocator>::operator=(_rbtree<T, Comp, Allocator> const& other)
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
+_rbtree<T, Comp, Allocator>::_insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
 {
 	node_pointer new_   = _init_tree_node(value);
 	node_pointer parent = _nil_node;
@@ -155,7 +155,7 @@ _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_valu
 		parent->_right = new_;
 	}
 	new_->_parent = parent;
-	display(__FUNCTION__, __LINE__);
+	_display(__FUNCTION__, __LINE__);
 	_insert_fixup(new_);
 	return new_;
 }
@@ -282,13 +282,13 @@ void _rbtree<T, Comp, Allocator>::_rotate_left(const _rbtree<T, Comp, Allocator>
 	}
 	child->_left = ptr;
 	ptr->_parent = child;
-	display(__FUNCTION__, __LINE__);
+	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
-	display(__FUNCTION__, __LINE__);
+	_display(__FUNCTION__, __LINE__);
 	node_pointer child = ptr->_left;
 	ptr->_left         = child->_right;
 	if (ptr->_right != _nil_node) {
@@ -305,7 +305,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator
 	}
 	child->_right = ptr;
 	ptr->_parent  = child;
-	display(__FUNCTION__, __LINE__);
+	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
@@ -350,7 +350,7 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 		}
 	}
 	_begin_node->_is_black = true;
-	display(__FUNCTION__, __LINE__);
+	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
@@ -532,7 +532,7 @@ std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::display(std::string func_name, int line) const
+void _rbtree<T, Comp, Allocator>::_display(std::string func_name, int line) const
 {
 	std::string dirpath;
 	std::string cmd;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -186,7 +186,7 @@ template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_transplant(
     _rbtree<T, Comp, Allocator>::node_pointer old_, _rbtree<T, Comp, Allocator>::node_pointer new_)
 {
-	if (old_->_parent == _nid_node) {
+	if (old_->_parent == _nil_node) {
 		_begin_node = new_;
 	} else if (_is_left_child(old_)) {
 		old_->_parent->_left = new_;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -46,7 +46,7 @@ class _rbtree
   public:
 	_rbtree()
 	{
-		_nil_node   = _allocate_tree_node(0);
+		_nil_node   = _init_tree_node(0);
 		_begin_node = _nil_node;
 	};
 	~_rbtree(){};
@@ -54,7 +54,7 @@ class _rbtree
 	_rbtree& operator=(_rbtree const& other);
 
   private:
-	node_pointer _allocate_tree_node(node_value_type v);
+	node_pointer _init_tree_node(node_value_type v);
 	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
 	node_pointer& _find_parent(node_pointer p);
 
@@ -67,7 +67,7 @@ class _rbtree
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
 {
-	node_pointer new_   = _allocate_tree_node(value);
+	node_pointer new_   = _init_tree_node(value);
 	node_pointer parent = _nil_node;
 
 	for (node_pointer current = _begin_node; current != _nil_node;) {
@@ -94,7 +94,7 @@ void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_allocate_tree_node(_rbtree<T, Comp, Allocator>::node_value_type v)
+_rbtree<T, Comp, Allocator>::_init_tree_node(_rbtree<T, Comp, Allocator>::node_value_type v)
 {
 	node_pointer ptr = new node_type;
 	ptr->_parent     = _nil_node;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -23,7 +23,7 @@ class _tree_node
 	value_type _value;
 	bool       _is_black;
 
-	_tree_node() : _left(NULL), _right(NULL), _parent(NULL), _value(0), _is_black(false){};
+	_tree_node() : _parent(NULL), _right(NULL), _left(NULL), _value(0), _is_black(false){};
 	_tree_node& operator=(_tree_node const& other)
 	{
 		if (*this != other) {
@@ -67,7 +67,10 @@ class _rbtree_iterator
 	{
 		return _x._ptr_ == _y._ptr_;
 	}
-	bool operator!=(const _rbtree_iterator& _x, const _rbtree_iterator& _y) { return !(_x == _y) }
+	friend bool operator!=(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
+	{
+		return !(_x == _y);
+	}
 };
 
 template <class T, class Comp, class Allocator>

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -11,6 +11,9 @@
 
 namespace ft {
 
+/* -------------------------------------------------------------------------- */
+/*                                  Tree Node                                 */
+/* -------------------------------------------------------------------------- */
 template <class T>
 class _tree_node
 {
@@ -44,7 +47,7 @@ class _tree_node
 namespace {
 
 /* -------------------------------------------------------------------------- */
-/*                                    utils                                   */
+/*                                    Utils                                   */
 /* -------------------------------------------------------------------------- */
 
 template <class _NodePtr>
@@ -121,6 +124,9 @@ _NodePtr _tree_prev_(_NodePtr ptr, _NodePtr _nil_node)
 
 } // namespace
 
+/* -------------------------------------------------------------------------- */
+/*                               RBtree Iterator                              */
+/* -------------------------------------------------------------------------- */
 template <class T>
 class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T>
 {
@@ -138,6 +144,7 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 	_rbtree_iterator() : _current_(NULL), _nil_(NULL) {}
 	_rbtree_iterator(pointer current, pointer nil) : _current_(current), _nil_(nil) {}
 
+	/* -------------------------- Access operators -------------------------- */
 	reference operator*() const { return _current_->_value; }
 	pointer   operator->() const { return _current_; }
 	/* ------------------------ Arithmetic operators ------------------------ */
@@ -174,6 +181,9 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 	}
 };
 
+/* -------------------------------------------------------------------------- */
+/*                                   RBtree                                   */
+/* -------------------------------------------------------------------------- */
 template <class T, class Comp, class Allocator>
 class _rbtree
 {
@@ -201,10 +211,11 @@ class _rbtree
 	node_pointer _delete(const value_type& value);
 	void         _display(std::string func_name = "", int line = -1) const;
 
+	/* ------------------------------ Iterators ----------------------------- */
   private:
 	node_pointer _init_tree_node_(value_type value);
 
-	/* ------------------------------- algorithms ------------------------------ */
+	/* ----------------------------- algorithms ----------------------------- */
 	node_pointer _find_recursive_(const node_pointer ptr, const value_type& value) const;
 	void         _transplant_(node_pointer old_ptr, node_pointer new_ptr);
 	void         _rotate_left_(node_pointer ptr);
@@ -212,7 +223,7 @@ class _rbtree
 	void         _insert_fixup_(node_pointer ptr);
 	void         _delete_fixup_(node_pointer ptr);
 
-	/* --------------------------------- debug --------------------------------- */
+	/* -------------------------------- debug ------------------------------- */
 	int  _check_tree_recursive_(node_pointer ptr, int black_count, int& invalid) const;
 	void _check_tree_validity_() const;
 	std::string

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -56,6 +56,9 @@ class _rbtree
   private:
 	node_pointer _init_tree_node(node_value_type v);
 
+	bool _is_left_child(node_pointer ptr);
+	bool _is_black(node_pointer ptr);
+
 	void _rotate_left(node_pointer ptr);
 	void _rotate_right(node_pointer ptr);
 	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
@@ -65,6 +68,24 @@ class _rbtree
 	void insert(const node_value_type& v);
 	void display();
 };
+
+
+/* -------------------------------------------------------------------------- */
+/*                                    utils                                   */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+bool _rbtree<T, Comp, Allocator>::_is_left_child(
+    const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+{
+	return (ptr == ptr->_parent->_left);
+}
+
+template <class T, class Comp, class Allocator>
+bool _rbtree<T, Comp, Allocator>::_is_black(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+{
+	return (ptr->_is_black);
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                   rotates                                  */
@@ -83,7 +104,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_left(const _rbtree<T, Comp, Allocator>
 	child->_parent      = parent;
 	if (parent == _nil_node) {
 		_begin_node = child;
-	} else if (ptr == parent->_left) {
+	} else if (_is_left_child(ptr)) {
 		parent->_left = child;
 	} else {
 		parent->_right = child;
@@ -105,7 +126,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator
 	child->_parent      = parent;
 	if (parent == _nil_node) {
 		_begin_node = child;
-	} else if (ptr == parent->_left) {
+	} else if (_is_left_child(ptr)) {
 		parent->_left = child;
 	} else {
 		parent->_right = child;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -135,14 +135,33 @@ class _rbtree_iterator
 	pointer _nil_;
 
   public:
-	_rbtree_iterator() : _curret_(NULL) {}
-	reference operator*() const;
-	pointer   operator->() const;
+	_rbtree_iterator() : _curret_(NULL), _nil_(NULL) {}
+	_rbtree_iterator(pointer current, pointer nil) : _curret_(current), _nil_(nil) {}
+	reference operator*() const { return _curret_->_value; }
+	pointer   operator->() const { return _curret_; }
 
-	_rbtree_iterator& operator++();
-	_rbtree_iterator  operator++(int);
-	_rbtree_iterator& operator--();
-	_rbtree_iterator  operator--(int);
+	_rbtree_iterator& operator++()
+	{
+		_current_ = _tree_next_(_current_, _nil_);
+		return *this;
+	}
+	_rbtree_iterator operator++(int)
+	{
+		_rbtree_iterator _tmp(*this);
+		++(*this);
+		return _tmp;
+	}
+	_rbtree_iterator& operator--()
+	{
+		_current_ = _tree_prev_(_current_, _nil_);
+		return *this;
+	}
+	_rbtree_iterator operator--(int)
+	{
+		_rbtree_iterator _tmp(*this);
+		--(*this);
+		return _tmp;
+	}
 
 	friend bool operator==(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
 	{

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -86,6 +86,39 @@ _NodePtr _tree_min_(_NodePtr ptr, _NodePtr _nil_node)
 	return ptr;
 }
 
+template <class _NodePtr>
+_NodePtr _tree_max_(_NodePtr ptr, _NodePtr _nil_node)
+{
+	while (ptr->_right != _nil_node) {
+		ptr = ptr->_right;
+	}
+	return ptr;
+}
+
+template <class _NodePtr>
+_NodePtr _tree_next_(_NodePtr ptr, _NodePtr _nil_node)
+{
+	if (ptr->_right != _nil_node) {
+		return _tree_min(ptr->_right, _nil_node);
+	}
+	while (!_is_left_child(ptr)) {
+		ptr = ptr->_parent;
+	}
+	return ptr->_pearent;
+}
+
+template <class _NodePtr>
+_NodePtr _tree_prev_(_NodePtr ptr, _NodePtr _nil_node)
+{
+	if (ptr->_left != _nil_node) {
+		return _tree_max(ptr->_left, _nil_node);
+	}
+	while (!_is_right_child(ptr)) {
+		ptr = ptr->_parent;
+	}
+	return ptr->_pearent;
+}
+
 } // namespace
 
 template <class T>

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -44,7 +44,11 @@ class _rbtree
 	allocator_type _alloc;
 
   public:
-	_rbtree() : _begin_node(NULL) { _nil_node = new node_type; };
+	_rbtree()
+	{
+		_nil_node   = new node_type;
+		_begin_node = _nil_node;
+	};
 	~_rbtree(){};
 	_rbtree(_rbtree const& other);
 	_rbtree& operator=(_rbtree const& other);

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -61,6 +61,9 @@ class _rbtree
 
 	void _rotate_left(node_pointer ptr);
 	void _rotate_right(node_pointer ptr);
+
+	void _insert_fixup(node_pointer v);
+
 	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
 	node_pointer& _find_parent(node_pointer p);
 
@@ -133,6 +136,49 @@ void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator
 	}
 	child->_right = ptr;
 	ptr->_parent  = child;
+
+/* -------------------------------------------------------------------------- */
+/*                                   inserts                                  */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::node_pointer ptr)
+{
+	node_pointer uncle;
+	while (!_is_black(ptr->_parent)) {
+		if (_is_left_child(ptr->_parent)) {
+			uncle = ptr->_parent->_parent->_right;
+			if (!_is_black(uncle)) {
+				ptr->_parent->_is_black   = true;
+				uncle->_is_black          = true;
+				uncle->_parent->_is_black = false;
+			} else {
+				if (!_is_left_child(ptr)) {
+					ptr = ptr->_parent;
+					_rotate_right(ptr);
+				}
+				ptr->_parent->_is_black          = true;
+				ptr->_parent->_parent->_is_black = false;
+				_rotate_left(ptr->_parent);
+			}
+		} else {
+			uncle = ptr->_parent->_parent->_left;
+			if (!_is_black(uncle)) {
+				ptr->_parent->_is_black   = true;
+				uncle->_is_black          = true;
+				uncle->_parent->_is_black = false;
+			} else {
+				if (_is_left_child(ptr)) {
+					ptr = ptr->_parent;
+					_rotate_left(ptr);
+				}
+				ptr->_parent->_is_black          = true;
+				ptr->_parent->_parent->_is_black = false;
+				_rotate_right(ptr->_parent);
+			}
+		}
+	}
+	_begin_node->_is_black = true;
 }
 
 template <class T, class Comp, class Allocator>
@@ -157,6 +203,7 @@ void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node
 		parent->_right = new_;
 	}
 	new_->_parent = parent;
+	_insert_fixup(new_);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -68,8 +68,7 @@ class _rbtree
 	node_pointer& _find_parent(node_pointer p);
 
   public:
-	void insert(const node_value_type& v);
-	void display();
+	node_pointer insert(const node_value_type& v);
 };
 
 
@@ -182,7 +181,8 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
+typename _rbtree<T, Comp, Allocator>::node_pointer
+_rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
 {
 	node_pointer new_   = _init_tree_node(value);
 	node_pointer parent = _nil_node;
@@ -197,6 +197,7 @@ void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node
 	}
 	if (parent == _nil_node) {
 		_begin_node = new_;
+		return new_;
 	} else if (value < parent->_value) {
 		parent->_left = new_;
 	} else {
@@ -204,6 +205,7 @@ void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node
 	}
 	new_->_parent = parent;
 	_insert_fixup(new_);
+	return new_;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -59,8 +59,12 @@ class _rbtree
   public:
 	_rbtree()
 	{
-		_nil_node            = _init_tree_node(0);
+		_nil_node            = new node_type;
 		_nil_node->_is_black = true;
+		_nil_node->_parent   = _nil_node;
+		_nil_node->_left     = _nil_node;
+		_nil_node->_right    = _nil_node;
+		_nil_node->_value    = 0;
 		_begin_node          = _nil_node;
 	};
 	~_rbtree(){};

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -77,6 +77,7 @@ class _rbtree
 	bool         _is_left_child(node_pointer ptr);
 	bool         _is_right_child(node_pointer ptr);
 	bool         _is_black(node_pointer ptr);
+	bool         _is_black(bool _is_black_);
 	bool         _is_red(node_pointer ptr);
 	node_pointer _tree_min(node_pointer ptr) const;
 
@@ -120,6 +121,12 @@ template <class T, class Comp, class Allocator>
 bool _rbtree<T, Comp, Allocator>::_is_black(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	return (ptr->_is_black);
+}
+
+template <class T, class Comp, class Allocator>
+bool _rbtree<T, Comp, Allocator>::_is_black(bool _is_black_)
+{
+	return (_is_black_);
 }
 
 template <class T, class Comp, class Allocator>

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -93,6 +93,9 @@ class _rbtree
 	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
 	node_pointer& _find_parent(node_pointer p);
 
+	int  _check_tree_recursive(node_pointer ptr, int black_count, int& invalid);
+	void _check_tree_validity();
+
 	node_pointer _find_recursive(const node_pointer ptr, const node_value_type& v) const;
 
   public:
@@ -445,6 +448,51 @@ _rbtree<T, Comp, Allocator>::_init_tree_node(_rbtree<T, Comp, Allocator>::node_v
 /* -------------------------------------------------------------------------- */
 
 template <class T, class Comp, class Allocator>
+int _rbtree<T, Comp, Allocator>::_check_tree_recursive(
+    _rbtree<T, Comp, Allocator>::node_pointer ptr, int black_counts, int& invalid)
+{
+	if (ptr == _nil_node) {
+		return black_counts;
+	}
+	if (ptr->_is_black) {
+		++black_counts;
+	}
+	if (_is_red(ptr) && (_is_red(ptr->_left) || _is_red(ptr->_right))) {
+		std::cerr << "4. the children of red must be black" << std::endl;
+		++invalid;
+	}
+	int total;
+	total = _check_tree_recursive(ptr->_right, black_counts, invalid);
+	if (total != _check_tree_recursive(ptr->_left, black_counts, invalid)) {
+		std::cerr << "5. count of black nodes must be the same" << std::endl;
+		++invalid;
+	}
+	return total;
+}
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_check_tree_validity()
+{
+	int invalid = 0;
+	if (_is_red(_begin_node)) {
+		std::cerr << "2. root must be black" << std::endl;
+		++invalid;
+	}
+	node_pointer ptr = _begin_node;
+	_check_tree_recursive(ptr, 0, invalid);
+	if (invalid) {
+		std::cerr << "\033[31m"
+		          << "ERROR: tree is wrong... ;("
+		          << "\033[0m" << std::endl;
+		// exit(EXIT_FAILURE);
+	} else {
+		std::cerr << "\033[32m"
+		          << "PASS: tree is correct! :)"
+		          << "\033[m" << std::endl;
+	}
+}
+
+template <class T, class Comp, class Allocator>
 std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
     _rbtree<T, Comp, Allocator>::node_pointer& v, std::string dirprefix, bool is_right)
 {
@@ -489,6 +537,7 @@ void _rbtree<T, Comp, Allocator>::display(std::string func_name, int line)
 	system(cmd.c_str());
 	cmd = "rm -Rf " + dirpath;
 	system(cmd.c_str());
+	_check_tree_validity();
 }
 
 } // namespace ft

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -15,13 +15,13 @@ class _tree_node
 {
   public:
 	typedef _tree_node<T>* pointer;
-	typedef T              _node_value_type;
+	typedef T              value_type;
 
-	pointer          _left;
-	pointer          _right;
-	pointer          _parent;
-	_node_value_type _value;
-	bool             _is_black;
+	pointer    _parent;
+	pointer    _right;
+	pointer    _left;
+	value_type _value;
+	bool       _is_black;
 
 	_tree_node() : _left(NULL), _right(NULL), _parent(NULL), _value(0), _is_black(false){};
 	_tree_node& operator=(_tree_node const& other)
@@ -44,7 +44,7 @@ template <class T, class Comp, class Allocator>
 class _rbtree
 {
   public:
-	typedef T              node_value_type;
+	typedef T              value_type;
 	typedef Comp           value_compare;
 	typedef Allocator      allocator_type;
 	typedef _tree_node<T>  node_type;
@@ -62,16 +62,16 @@ class _rbtree
 	_rbtree(_rbtree const& other);
 	_rbtree& operator=(_rbtree const& other);
 
-	node_pointer _find(const node_value_type& value) const;
-	node_pointer _insert(const node_value_type& value);
-	node_pointer _delete(const node_value_type& value);
+	node_pointer _find(const value_type& value) const;
+	node_pointer _insert(const value_type& value);
+	node_pointer _delete(const value_type& value);
 	void         _display(std::string func_name = "", int line = -1) const;
 
   private:
-	node_pointer _init_tree_node_(node_value_type value);
+	node_pointer _init_tree_node_(value_type value);
 
 	/* ------------------------------- algorithms ------------------------------ */
-	node_pointer _find_recursive_(const node_pointer ptr, const node_value_type& value) const;
+	node_pointer _find_recursive_(const node_pointer ptr, const value_type& value) const;
 	void         _transplant_(node_pointer old_ptr, node_pointer new_ptr);
 	void         _rotate_left_(node_pointer ptr);
 	void         _rotate_right_(node_pointer ptr);
@@ -135,7 +135,7 @@ _rbtree<T, Comp, Allocator>::operator=(_rbtree<T, Comp, Allocator> const& other)
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
+_rbtree<T, Comp, Allocator>::_insert(const _rbtree<T, Comp, Allocator>::value_type& value)
 {
 	node_pointer new_   = _init_tree_node_(value);
 	node_pointer parent = _nil_node;
@@ -163,14 +163,14 @@ _rbtree<T, Comp, Allocator>::_insert(const _rbtree<T, Comp, Allocator>::node_val
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_find(const _rbtree<T, Comp, Allocator>::node_value_type& value) const
+_rbtree<T, Comp, Allocator>::_find(const _rbtree<T, Comp, Allocator>::value_type& value) const
 {
 	return _find_recursive_(_begin_node, value);
 }
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_delete(const _rbtree<T, Comp, Allocator>::node_value_type& value)
+_rbtree<T, Comp, Allocator>::_delete(const _rbtree<T, Comp, Allocator>::value_type& value)
 {
 	node_pointer ptr              = _find(value);
 	node_pointer fix_trigger_node = ptr;
@@ -212,7 +212,7 @@ _rbtree<T, Comp, Allocator>::_delete(const _rbtree<T, Comp, Allocator>::node_val
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_init_tree_node_(_rbtree<T, Comp, Allocator>::node_value_type value)
+_rbtree<T, Comp, Allocator>::_init_tree_node_(_rbtree<T, Comp, Allocator>::value_type value)
 {
 	node_pointer ptr = new node_type;
 	ptr->_parent     = _nil_node;
@@ -231,7 +231,7 @@ _rbtree<T, Comp, Allocator>::_init_tree_node_(_rbtree<T, Comp, Allocator>::node_
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::_find_recursive_(const _rbtree<T, Comp, Allocator>::node_pointer ptr,
-    const _rbtree<T, Comp, Allocator>::node_value_type& value) const
+    const _rbtree<T, Comp, Allocator>::value_type& value) const
 {
 	node_pointer found;
 

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -18,8 +18,8 @@ template <class T>
 class _tree_node
 {
   public:
-	typedef _tree_node<T>* pointer;
-	typedef T              value_type;
+	typedef T                       value_type;
+	typedef _tree_node<value_type>* pointer;
 
 	pointer    _parent;
 	pointer    _right;
@@ -188,11 +188,11 @@ template <class T, class Comp, class Allocator>
 class _rbtree
 {
   public:
-	typedef T              value_type;
-	typedef Comp           value_compare;
-	typedef Allocator      allocator_type;
-	typedef _tree_node<T>  node_type;
-	typedef _tree_node<T>* node_pointer;
+	typedef T                       value_type;
+	typedef Comp                    value_compare;
+	typedef Allocator               allocator_type;
+	typedef _tree_node<value_type>  node_type;
+	typedef _tree_node<value_type>* node_pointer;
 
 	typedef _rbtree_iterator<value_type>       iterator;
 	typedef _rbtree_iterator<const value_type> const_iterator;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -74,10 +74,11 @@ class _rbtree
   private:
 	node_pointer _init_tree_node(node_value_type v);
 
-	bool _is_left_child(node_pointer ptr);
-	bool _is_right_child(node_pointer ptr);
-	bool _is_black(node_pointer ptr);
-	bool _is_red(node_pointer ptr);
+	bool         _is_left_child(node_pointer ptr);
+	bool         _is_right_child(node_pointer ptr);
+	bool         _is_black(node_pointer ptr);
+	bool         _is_red(node_pointer ptr);
+	node_pointer _tree_min(node_pointer ptr) const;
 
 	void _transplant(node_pointer old_, node_pointer new_);
 
@@ -125,6 +126,16 @@ template <class T, class Comp, class Allocator>
 bool _rbtree<T, Comp, Allocator>::_is_red(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	return (!ptr->_is_black);
+}
+
+template <class T, class Comp, class Allocator>
+typename _rbtree<T, Comp, Allocator>::node_pointer
+_rbtree<T, Comp, Allocator>::_tree_min(_rbtree<T, Comp, Allocator>::node_pointer ptr) const
+{
+	while (ptr->_left != _nil_node) {
+		ptr = ptr->_left;
+	}
+	return ptr;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -94,6 +94,7 @@ class _rbtree
 	node_pointer _find_recursive(const node_pointer ptr, const node_value_type& v) const;
 
   public:
+	node_pointer _delete(const node_value_type& v);
 	node_pointer _find(const node_value_type& v) const;
 	node_pointer insert(const node_value_type& v);
 	void         display(std::string func_name = "", int line = -1);
@@ -193,6 +194,48 @@ void _rbtree<T, Comp, Allocator>::_transplant(
 		old_->_parent->_right = new_;
 	}
 	new_->_parent = old_->_parent;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   deletes                                  */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+typename _rbtree<T, Comp, Allocator>::node_pointer
+_rbtree<T, Comp, Allocator>::_delete(const _rbtree<T, Comp, Allocator>::node_value_type& value)
+{
+	node_pointer ptr              = _find(value);
+	node_pointer fix_trigger_node = ptr;
+	node_pointer child_to_recolor;
+	bool         original_color = _is_black(fix_trigger_node);
+
+	if (ptr->_left == _nil_node) {
+		child_to_recolor = ptr->_right;
+		_transplant(ptr, ptr->_right);
+	} else if (ptr->_right == _nil_node) {
+		child_to_recolor = ptr->_left;
+		_transplant(ptr, ptr->_left);
+	} else {
+		fix_trigger_node = _tree_min(ptr->_right);
+		original_color   = _is_black(fix_trigger_node);
+		child_to_recolor = fix_trigger_node->_right;
+		if (fix_trigger_node->_parent == ptr) {
+			child_to_recolor->_parent = fix_trigger_node;
+		} else {
+			_transplant(fix_trigger_node, fix_trigger_node->_right);
+			fix_trigger_node->_right          = ptr->_right;
+			fix_trigger_node->_right->_parent = fix_trigger_node;
+		}
+		_transplant(ptr, fix_trigger_node);
+		fix_trigger_node->_left          = ptr->_left;
+		fix_trigger_node->_left->_parent = fix_trigger_node;
+		fix_trigger_node->_is_black      = ptr->_is_black;
+	}
+
+	if (_is_black(original_color)) {
+		// fixup;
+	}
+	return ptr;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -194,6 +194,9 @@ class _rbtree
 	typedef _tree_node<T>  node_type;
 	typedef _tree_node<T>* node_pointer;
 
+	typedef _rbtree_iterator<value_type>       iterator;
+	typedef _rbtree_iterator<const value_type> const_iterator;
+
   private:
 	node_pointer   _begin_node;
 	node_pointer   _nil_node;
@@ -212,6 +215,11 @@ class _rbtree
 	void         _display(std::string func_name = "", int line = -1) const;
 
 	/* ------------------------------ Iterators ----------------------------- */
+	iterator       begin() { return iterator(_begin_node, _nil_node); }
+	const_iterator begin() const { return iterator(_begin_node, _nil_node); }
+	iterator       end() { return iterator(_tree_max_(_begin_node, _nil_node), _nil_node); }
+	const_iterator end() const { return iterator(_tree_max_(_begin_node, _nil_node), _nil_node); }
+
   private:
 	node_pointer _init_tree_node_(value_type value);
 

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -24,8 +24,21 @@ class _tree_node
 	bool             _is_black;
 
 	_tree_node() : _left(NULL), _right(NULL), _parent(NULL), _value(0), _is_black(false){};
-};
+	_tree_node& operator=(_tree_node const& other)
+	{
+		if (*this != other) {
+			_left     = other._left;
+			_right    = other._right;
+			_parent   = other._parent;
+			_value    = other._value;
+			_is_black = other._is_black;
+		}
+		return *this;
+	};
 
+  private:
+	_tree_node(_tree_node const& other);
+};
 
 template <class T, class Comp, class Allocator>
 class _rbtree
@@ -136,6 +149,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator
 	}
 	child->_right = ptr;
 	ptr->_parent  = child;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                   inserts                                  */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -291,7 +291,7 @@ _rbtree<T, Comp, Allocator>::_insert(const _rbtree<T, Comp, Allocator>::value_ty
 
 	for (node_pointer current = _begin_node; current != _nil_node;) {
 		parent = current;
-		if (value < current->_value) {
+		if (_comp(value, current->_value)) {
 			current = current->_left;
 		} else {
 			current = current->_right;
@@ -299,7 +299,7 @@ _rbtree<T, Comp, Allocator>::_insert(const _rbtree<T, Comp, Allocator>::value_ty
 	}
 	if (parent == _nil_node) {
 		_begin_node = new_;
-	} else if (value < parent->_value) {
+	} else if (_comp(value, parent->_value)) {
 		parent->_left = new_;
 	} else {
 		parent->_right = new_;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -57,19 +57,15 @@ class _rbtree
 	allocator_type _alloc;
 
   public:
-	_rbtree()
-	{
-		_nil_node            = new node_type;
-		_nil_node->_is_black = true;
-		_nil_node->_parent   = _nil_node;
-		_nil_node->_left     = _nil_node;
-		_nil_node->_right    = _nil_node;
-		_nil_node->_value    = 0;
-		_begin_node          = _nil_node;
-	};
+	_rbtree();
 	~_rbtree(){};
 	_rbtree(_rbtree const& other);
 	_rbtree& operator=(_rbtree const& other);
+
+	node_pointer _delete(const node_value_type& v);
+	node_pointer _find(const node_value_type& v) const;
+	node_pointer insert(const node_value_type& v);
+	void         display(std::string func_name = "", int line = -1);
 
   private:
 	node_pointer _init_tree_node(node_value_type v);
@@ -90,20 +86,29 @@ class _rbtree
 
 	void _insert_fixup(node_pointer v);
 
-	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
-	node_pointer& _find_parent(node_pointer p);
+	std::string _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
 
 	int  _check_tree_recursive(node_pointer ptr, int black_count, int& invalid);
 	void _check_tree_validity();
 
 	node_pointer _find_recursive(const node_pointer ptr, const node_value_type& v) const;
-
-  public:
-	node_pointer _delete(const node_value_type& v);
-	node_pointer _find(const node_value_type& v) const;
-	node_pointer insert(const node_value_type& v);
-	void         display(std::string func_name = "", int line = -1);
 };
+
+/* -------------------------------------------------------------------------- */
+/*                                constructors                                */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+_rbtree<T, Comp, Allocator>::_rbtree()
+{
+	_nil_node            = new node_type;
+	_nil_node->_is_black = true;
+	_nil_node->_parent   = _nil_node;
+	_nil_node->_left     = _nil_node;
+	_nil_node->_right    = _nil_node;
+	_nil_node->_value    = 0;
+	_begin_node          = _nil_node;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                    utils                                   */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -71,7 +71,9 @@ class _rbtree
 	node_pointer _init_tree_node(node_value_type v);
 
 	bool _is_left_child(node_pointer ptr);
+	bool _is_right_child(node_pointer ptr);
 	bool _is_black(node_pointer ptr);
+	bool _is_red(node_pointer ptr);
 
 	void _rotate_left(node_pointer ptr);
 	void _rotate_right(node_pointer ptr);
@@ -98,9 +100,22 @@ bool _rbtree<T, Comp, Allocator>::_is_left_child(
 }
 
 template <class T, class Comp, class Allocator>
+bool _rbtree<T, Comp, Allocator>::_is_right_child(
+    const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+{
+	return (ptr == ptr->_parent->_right);
+}
+
+template <class T, class Comp, class Allocator>
 bool _rbtree<T, Comp, Allocator>::_is_black(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	return (ptr->_is_black);
+}
+
+template <class T, class Comp, class Allocator>
+bool _rbtree<T, Comp, Allocator>::_is_red(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+{
+	return (!ptr->_is_black);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -1,0 +1,106 @@
+#ifndef RBTREE_HPP
+#define RBTREE_HPP
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace ft {
+
+template <class T>
+class _tree_node
+{
+  public:
+	typedef _tree_node<T>* pointer;
+	typedef T              _node_value_type;
+
+	pointer          _left;
+	pointer          _right;
+	pointer          _parent;
+	_node_value_type _value;
+	bool             _is_black;
+
+	_tree_node() : _left(NULL), _right(NULL), _parent(NULL), _value(0), _is_black(false){};
+};
+
+
+template <class T, class Comp, class Allocator>
+class _rbtree
+{
+  public:
+	typedef T              node_value_type;
+	typedef Comp           value_compare;
+	typedef Allocator      allocator_type;
+	typedef _tree_node<T>  node_type;
+	typedef _tree_node<T>* node_pointer;
+
+  private:
+	node_pointer   _begin_node;
+	node_pointer   _nil_node;
+	value_compare  _comp;
+	allocator_type _alloc;
+
+  public:
+	_rbtree() : _begin_node(NULL) { _nil_node = new node_type; };
+	~_rbtree(){};
+	_rbtree(_rbtree const& other);
+	_rbtree& operator=(_rbtree const& other);
+
+	std::string   _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
+	node_pointer& _find_parent(node_pointer p);
+
+  public:
+	void display();
+};
+
+/* -------------------------------------------------------------------------- */
+/*                                    debug                                   */
+/* -------------------------------------------------------------------------- */
+
+template <class T, class Comp, class Allocator>
+std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
+    _rbtree<T, Comp, Allocator>::node_pointer& v, std::string dirprefix, bool is_right)
+{
+	if (v == _nil_node)
+		return "";
+
+	std::stringstream current_dirname;
+	current_dirname << dirprefix << (is_right ? "R_" : "L_") << v->_value;
+
+	/* delete all before creating the root directory */
+	if (dirprefix == "./") {
+		std::string cmd = "rm -Rf " + current_dirname.str();
+		system(cmd.c_str());
+	}
+	dirprefix = current_dirname.str();
+
+	mode_t mode;
+	mode = v->_is_black ? 0777 : 0755; /* to create color difference */
+	mkdir(dirprefix.c_str(), mode);
+	chmod(dirprefix.c_str(), mode);
+
+	_node_to_dir(v->_right, dirprefix + "/", true);
+	_node_to_dir(v->_left, dirprefix + "/", false);
+	return dirprefix;
+}
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::display()
+{
+	std::string dirpath;
+	std::string cmd;
+	dirpath = _node_to_dir(_begin_node, "./", true);
+
+	setenv("LS_COLORS", "di=00;91:ow=30;107", 1); /* set Red & Black color */
+	cmd = "tree -C " + dirpath;
+	system(cmd.c_str());
+	cmd = "rm -Rf " + dirpath;
+	system(cmd.c_str());
+}
+
+} // namespace ft
+
+#endif /* RBTREE_HPP */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -127,7 +127,7 @@ _NodePtr _tree_prev_(_NodePtr ptr, _NodePtr _nil_node)
 /* -------------------------------------------------------------------------- */
 /*                               RBtree Iterator                              */
 /* -------------------------------------------------------------------------- */
-template <class T>
+template <class T, class _NodePtr>
 class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T>
 {
   public:
@@ -137,12 +137,12 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 	typedef value_type*                     pointer;
 
   private:
-	pointer _current_;
-	pointer _nil_;
+	_NodePtr _current_;
+	_NodePtr _nil_;
 
   public:
 	_rbtree_iterator() : _current_(NULL), _nil_(NULL) {}
-	_rbtree_iterator(pointer current, pointer nil) : _current_(current), _nil_(nil) {}
+	_rbtree_iterator(_NodePtr current, _NodePtr nil) : _current_(current), _nil_(nil) {}
 
 	/* -------------------------- Access operators -------------------------- */
 	reference operator*() const { return _current_->_value; }
@@ -194,8 +194,8 @@ class _rbtree
 	typedef _tree_node<value_type>  node_type;
 	typedef _tree_node<value_type>* node_pointer;
 
-	typedef _rbtree_iterator<value_type>       iterator;
-	typedef _rbtree_iterator<const value_type> const_iterator;
+	typedef _rbtree_iterator<value_type, node_pointer>       iterator;
+	typedef _rbtree_iterator<const value_type, node_pointer> const_iterator;
 
   private:
 	node_pointer   _begin_node;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -122,7 +122,7 @@ _NodePtr _tree_prev_(_NodePtr ptr, _NodePtr _nil_node)
 } // namespace
 
 template <class T>
-class _rbtree_iterator
+class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T>
 {
   public:
 	typedef std::bidirectional_iterator_tag iterator_category;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -180,15 +180,15 @@ template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::node_pointer ptr)
 {
 	node_pointer uncle;
-	while (!_is_black(ptr->_parent)) {
+	while (_is_red(ptr->_parent)) {
 		if (_is_left_child(ptr->_parent)) {
 			uncle = ptr->_parent->_parent->_right;
-			if (!_is_black(uncle)) {
+			if (_is_red(uncle)) {
 				ptr->_parent->_is_black   = true;
 				uncle->_is_black          = true;
 				uncle->_parent->_is_black = false;
 			} else {
-				if (!_is_left_child(ptr)) {
+				if (_is_right_child(ptr)) {
 					ptr = ptr->_parent;
 					_rotate_left(ptr);
 				}
@@ -198,7 +198,7 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup(_rbtree<T, Comp, Allocator>::nod
 			}
 		} else {
 			uncle = ptr->_parent->_parent->_left;
-			if (!_is_black(uncle)) {
+			if (_is_red(uncle)) {
 				ptr->_parent->_is_black   = true;
 				uncle->_is_black          = true;
 				uncle->_parent->_is_black = false;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -118,7 +118,7 @@ std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
 		return "";
 
 	std::stringstream current_dirname;
-	current_dirname << dirprefix << (is_right ? "R_" : "L_") << v->_value;
+	current_dirname << dirprefix << (is_right ? "-R_" : "_L_") << v->_value;
 
 	/* delete all before creating the root directory */
 	if (dirprefix == "./") {

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -197,6 +197,8 @@ class _rbtree
 	typedef _rbtree_iterator<value_type, node_pointer>       iterator;
 	typedef _rbtree_iterator<const value_type, node_pointer> const_iterator;
 
+	typedef typename Allocator::template rebind<node_type>::other node_allocator;
+
   private:
 	node_pointer   _begin_node;
 	node_pointer   _nil_node;
@@ -245,7 +247,8 @@ class _rbtree
 template <class T, class Comp, class Allocator>
 _rbtree<T, Comp, Allocator>::_rbtree()
 {
-	_nil_node            = new node_type;
+	node_allocator node_alloc;
+	_nil_node            = node_alloc.allocate(1);
 	_nil_node->_is_black = true;
 	_nil_node->_parent   = _nil_node;
 	_nil_node->_left     = _nil_node;
@@ -256,7 +259,8 @@ _rbtree<T, Comp, Allocator>::_rbtree()
 template <class T, class Comp, class Allocator>
 _rbtree<T, Comp, Allocator>::_rbtree(_rbtree<T, Comp, Allocator> const& other)
 {
-	_nil_node   = new node_type;
+	node_allocator node_alloc;
+	_nil_node   = node_alloc.allocate(1);
 	_nil_node   = other._nil_node;
 	_begin_node = other._begin_node;
 	_alloc      = other._alloc;
@@ -268,7 +272,8 @@ _rbtree<T, Comp, Allocator>&
 _rbtree<T, Comp, Allocator>::operator=(_rbtree<T, Comp, Allocator> const& other)
 {
 	if (this != &other) {
-		_nil_node   = new node_type;
+		node_allocator node_alloc;
+		_nil_node   = node_alloc.allocate(1);
 		_nil_node   = other._nil_node;
 		_begin_node = other._begin_node;
 		_alloc      = other._alloc;
@@ -358,12 +363,13 @@ template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::_init_tree_node_(_rbtree<T, Comp, Allocator>::value_type value)
 {
-	node_pointer ptr = new node_type;
-	ptr->_parent     = _nil_node;
-	ptr->_right      = _nil_node;
-	ptr->_left       = _nil_node;
-	ptr->_value      = value;
-	ptr->_is_black   = false;
+	node_allocator node_alloc;
+	node_pointer   ptr = node_alloc.allocate(1);
+	ptr->_parent       = _nil_node;
+	ptr->_right        = _nil_node;
+	ptr->_left         = _nil_node;
+	ptr->_value        = value;
+	ptr->_is_black     = false;
 
 	return ptr;
 }

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -57,8 +57,38 @@ class _rbtree
 	node_pointer& _find_parent(node_pointer p);
 
   public:
+	void insert(const node_value_type& v);
 	void display();
 };
+
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_value_type& value)
+{
+	node_pointer new_   = new node_type;
+	node_pointer parent = _nil_node;
+
+	for (node_pointer current = _begin_node; current != _nil_node;) {
+		parent = current;
+		if (value < current->_value) {
+			current = current->_left;
+		} else {
+			current = current->_right;
+		}
+	}
+	if (parent == _nil_node) {
+		_begin_node = new_;
+	} else if (value < parent->_value) {
+		parent->_left = new_;
+	} else {
+		parent->_right = new_;
+	}
+	new_->_parent   = parent;
+	new_->_right    = _nil_node;
+	new_->_left     = _nil_node;
+	new_->_value    = value;
+	new_->_is_black = false;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                    debug                                   */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -102,24 +102,24 @@ template <class _NodePtr>
 _NodePtr _tree_next_(_NodePtr ptr, _NodePtr _nil_node)
 {
 	if (ptr->_right != _nil_node) {
-		return _tree_min(ptr->_right, _nil_node);
+		return _tree_min_(ptr->_right, _nil_node);
 	}
-	while (!_is_left_child(ptr)) {
+	while (!_is_left_child_(ptr)) {
 		ptr = ptr->_parent;
 	}
-	return ptr->_pearent;
+	return ptr->_parent;
 }
 
 template <class _NodePtr>
 _NodePtr _tree_prev_(_NodePtr ptr, _NodePtr _nil_node)
 {
 	if (ptr->_left != _nil_node) {
-		return _tree_max(ptr->_left, _nil_node);
+		return _tree_max_(ptr->_left, _nil_node);
 	}
-	while (!_is_right_child(ptr)) {
+	while (!_is_right_child_(ptr)) {
 		ptr = ptr->_parent;
 	}
-	return ptr->_pearent;
+	return ptr->_parent;
 }
 
 } // namespace
@@ -146,7 +146,7 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 
 	/* -------------------------- Access operators -------------------------- */
 	reference operator*() const { return _current_->_value; }
-	pointer   operator->() const { return _current_; }
+	pointer   operator->() const { return &_current_->_value; }
 	/* ------------------------ Arithmetic operators ------------------------ */
 	_rbtree_iterator& operator++()
 	{
@@ -173,7 +173,7 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 	/* ------------------------ Non-member functions ------------------------ */
 	friend bool operator==(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
 	{
-		return _x._curret_ == _y._curret_;
+		return _x._current_ == _y._current_;
 	}
 	friend bool operator!=(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
 	{

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -65,7 +65,7 @@ class _rbtree
 	node_pointer _find(const node_value_type& v) const;
 	node_pointer insert(const node_value_type& v);
 	node_pointer _delete(const node_value_type& v);
-	void         display(std::string func_name = "", int line = -1);
+	void         display(std::string func_name = "", int line = -1) const;
 
   private:
 	node_pointer _init_tree_node(node_value_type v);
@@ -79,17 +79,17 @@ class _rbtree
 	void         _delete_fixup(node_pointer ptr);
 
 	/* --------------------------------- utils --------------------------------- */
-	bool         _is_left_child(node_pointer ptr);
-	bool         _is_right_child(node_pointer ptr);
-	bool         _is_black(node_pointer ptr);
-	bool         _is_black(bool _is_black_);
-	bool         _is_red(node_pointer ptr);
+	bool         _is_left_child(const node_pointer ptr) const;
+	bool         _is_right_child(const node_pointer ptr) const;
+	bool         _is_black(const node_pointer ptr) const;
+	bool         _is_black(bool _is_black_) const;
+	bool         _is_red(const node_pointer ptr) const;
 	node_pointer _tree_min(node_pointer ptr) const;
 
 	/* --------------------------------- debug --------------------------------- */
-	int         _check_tree_recursive(node_pointer ptr, int black_count, int& invalid);
-	void        _check_tree_validity();
-	std::string _node_to_dir(node_pointer& v, std::string dirprefix, bool is_right);
+	int         _check_tree_recursive(node_pointer ptr, int black_count, int& invalid) const;
+	void        _check_tree_validity() const;
+	std::string _node_to_dir(const node_pointer& v, std::string dirprefix, bool is_right) const;
 };
 
 /* -------------------------------------------------------------------------- */
@@ -390,32 +390,33 @@ void _rbtree<T, Comp, Allocator>::_delete_fixup(const _rbtree<T, Comp, Allocator
 
 template <class T, class Comp, class Allocator>
 bool _rbtree<T, Comp, Allocator>::_is_left_child(
-    const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+    const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	return (ptr == ptr->_parent->_left);
 }
 
 template <class T, class Comp, class Allocator>
 bool _rbtree<T, Comp, Allocator>::_is_right_child(
-    const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+    const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	return (ptr == ptr->_parent->_right);
 }
 
 template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_black(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+bool _rbtree<T, Comp, Allocator>::_is_black(
+    const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	return (ptr->_is_black);
 }
 
 template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_black(bool _is_black_)
+bool _rbtree<T, Comp, Allocator>::_is_black(bool _is_black_) const
 {
 	return (_is_black_);
 }
 
 template <class T, class Comp, class Allocator>
-bool _rbtree<T, Comp, Allocator>::_is_red(const _rbtree<T, Comp, Allocator>::node_pointer ptr)
+bool _rbtree<T, Comp, Allocator>::_is_red(const _rbtree<T, Comp, Allocator>::node_pointer ptr) const
 {
 	return (!ptr->_is_black);
 }
@@ -436,7 +437,7 @@ _rbtree<T, Comp, Allocator>::_tree_min(_rbtree<T, Comp, Allocator>::node_pointer
 
 template <class T, class Comp, class Allocator>
 int _rbtree<T, Comp, Allocator>::_check_tree_recursive(
-    _rbtree<T, Comp, Allocator>::node_pointer ptr, int black_counts, int& invalid)
+    _rbtree<T, Comp, Allocator>::node_pointer ptr, int black_counts, int& invalid) const
 {
 	if (ptr == _nil_node) {
 		return black_counts;
@@ -458,7 +459,7 @@ int _rbtree<T, Comp, Allocator>::_check_tree_recursive(
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_check_tree_validity()
+void _rbtree<T, Comp, Allocator>::_check_tree_validity() const
 {
 	int invalid = 0;
 	if (_is_red(_begin_node)) {
@@ -481,7 +482,7 @@ void _rbtree<T, Comp, Allocator>::_check_tree_validity()
 
 template <class T, class Comp, class Allocator>
 std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
-    _rbtree<T, Comp, Allocator>::node_pointer& v, std::string dirprefix, bool is_right)
+    const _rbtree<T, Comp, Allocator>::node_pointer& v, std::string dirprefix, bool is_right) const
 {
 	if (v == _nil_node)
 		return "";
@@ -507,7 +508,7 @@ std::string _rbtree<T, Comp, Allocator>::_node_to_dir(
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::display(std::string func_name, int line)
+void _rbtree<T, Comp, Allocator>::display(std::string func_name, int line) const
 {
 	std::string dirpath;
 	std::string cmd;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -231,7 +231,6 @@ _rbtree<T, Comp, Allocator>::insert(const _rbtree<T, Comp, Allocator>::node_valu
 	}
 	if (parent == _nil_node) {
 		_begin_node = new_;
-		return new_;
 	} else if (value < parent->_value) {
 		parent->_left = new_;
 	} else {

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -85,7 +85,6 @@ class _rbtree
 	void         display(std::string func_name = "", int line = -1);
 };
 
-
 /* -------------------------------------------------------------------------- */
 /*                                    utils                                   */
 /* -------------------------------------------------------------------------- */
@@ -113,7 +112,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_left(const _rbtree<T, Comp, Allocator>
 	node_pointer child = ptr->_right;
 	ptr->_right        = child->_left;
 	if (ptr->_right != _nil_node) {
-		ptr->_right->parent = ptr;
+		ptr->_right->_parent = ptr;
 	}
 
 	node_pointer parent = ptr->_parent;
@@ -135,7 +134,7 @@ void _rbtree<T, Comp, Allocator>::_rotate_right(const _rbtree<T, Comp, Allocator
 	node_pointer child = ptr->_left;
 	ptr->_left         = child->_right;
 	if (ptr->_right != _nil_node) {
-		ptr->_right->parent = ptr;
+		ptr->_right->_parent = ptr;
 	}
 
 	node_pointer parent = ptr->_parent;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -59,8 +59,9 @@ class _rbtree
   public:
 	_rbtree()
 	{
-		_nil_node   = _init_tree_node(0);
-		_begin_node = _nil_node;
+		_nil_node            = _init_tree_node(0);
+		_nil_node->_is_black = true;
+		_begin_node          = _nil_node;
 	};
 	~_rbtree(){};
 	_rbtree(_rbtree const& other);

--- a/includes/type_traits.hpp
+++ b/includes/type_traits.hpp
@@ -1,6 +1,8 @@
 #ifndef TYPE_TRAITS_HPP
 #define TYPE_TRAITS_HPP
 
+#include <iostream>
+
 namespace ft {
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
- close #44
- add: debug fucntion inside map class
- update: constructor
- add: basic unbalanced-red insert
- add: _allocate_tree_node
- rename: _allocate_tree_node -> _init_tree_node
- update: prefix of R & L for display order
- add: _rotate_right/left
- add: _is_left_child / _is_black()
- add: initial _insert_fixup
- update: insert to return node_pointer
- update: display() add args  __FILE__ and __LINE__
- add: tree_node copy constructor
- fix: for compilation
- update: constructor nil node color black
- add: error management for display()
- FIX: left <-> RIGHT
-  add: _is_right_child / _is_red()
- fix: initialize _nil_node manually
- fix: color first node to black
- add: display functions
- update: use _is_red / is_right
- fix: update ptr to grand parents
- add: _transplant()
- add: _find()
- add: _tree_min()
- add: _is_black overload
- add: _delete()
- fix: typo (compile error)
- add: _delete_fixup
- add: debug _check_tree_validity()
- style: move constructor, public member func definitions
- style: reorder functions
- add: const qualifiers
- style: rename variables
- add: copy constructor, operator= declarations
- fix: typo
- add: prefix _ for publlic funcs
- add: suffix _ for private funcs
- rename: node_value_type -> value_type
- add: basic iterator class definitions
- fix: compilation errors
- update: separate utils from _rbtree class
- style: rename ptr -> current
- add: utils functions; max, next, prev
- add: iterator implementations
- fix: typo
- update: inherits from std::iterator
- style: update formatted comments
- add: iterators to class _rbtree
- update: call value_type instead of T
- fix: compile error on init value
- fix: add include to type_traits.hpp
- add: _NodePtr for rbtree iterator template
- fix: all compilation errors
- update: set _base variable
- fix: iterator typedef
- add: Iterators implementations
- add: rebind; resolve #45
- update: use _comp; resolve #46
