### PR TITLE
fix/#56map bugs

### DIFF
--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -96,7 +96,7 @@ class map
 	void clear() { _tree.clear(); }
 	// insert
 	ft::pair<iterator, bool> insert(const value_type& value) { return _tree._insert(value); };
-	iterator                 insert(iterator hint, const value_type& value){};
+	iterator insert(iterator hint, const value_type& value) { return _tree._insert(hint, value); };
 	template <class InputIt>
 	void insert(InputIt first, InputIt last)
 	{
@@ -231,7 +231,9 @@ bool operator>=(
 /* -------------------------------------------------------------------------- */
 template <class Key, class T, class Compare, class Alloc>
 void swap(std::map<Key, T, Compare, Alloc>& lhs, std::map<Key, T, Compare, Alloc>& rhs)
-{}
+{
+	lhs.swap(rhs);
+}
 
 } // namespace ft
 

--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -105,7 +105,7 @@ class map
 	// erase
 	void      erase(iterator pos) { _tree.erase(pos); };
 	void      erase(iterator first, iterator last) { _tree.erase(first, last); };
-	size_type erase(const Key& key) { _tree.erase(key); };
+	size_type erase(const Key& key) { return _tree.erase(key); };
 	// swap
 	void swap(map& other) { _tree.swap(other._tree); };
 	/* --------------------------------- Lookup -------------------------------- */

--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -230,7 +230,7 @@ bool operator>=(
 /*                                  std::swap                                 */
 /* -------------------------------------------------------------------------- */
 template <class Key, class T, class Compare, class Alloc>
-void swap(std::map<Key, T, Compare, Alloc>& lhs, std::map<Key, T, Compare, Alloc>& rhs)
+void swap(ft::map<Key, T, Compare, Alloc>& lhs, ft::map<Key, T, Compare, Alloc>& rhs)
 {
 	lhs.swap(rhs);
 }

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -120,22 +120,28 @@ _NodePtr _tree_prev_(_NodePtr ptr, _NodePtr _nil)
 /* -------------------------------------------------------------------------- */
 /*                               RBtree Iterator                              */
 /* -------------------------------------------------------------------------- */
-template <class T, class _NodePtr>
+template <class T, class NodeType>
 class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T>
 {
   public:
-	typedef std::bidirectional_iterator_tag iterator_category;
-	typedef T                               value_type;
-	typedef value_type&                     reference;
-	typedef value_type*                     pointer;
+	typedef NodeType*                                                  iterator_type;
+	typedef typename iterator_traits<iterator_type>::difference_type   difference_type;
+	typedef typename iterator_traits<iterator_type>::value_type        node_type;
+	typedef typename iterator_traits<iterator_type>::pointer           node_ptr;
+	typedef typename iterator_traits<iterator_type>::reference         node_ref;
+	typedef typename iterator_traits<iterator_type>::iterator_category iterator_category;
+
+	typedef T           value_type;
+	typedef value_type& reference;
+	typedef value_type* pointer;
 
   private:
-	_NodePtr _current_;
-	_NodePtr _nil_;
+	node_ptr _current_;
+	node_ptr _nil_;
 
   public:
 	_rbtree_iterator() : _current_(NULL), _nil_(NULL) {}
-	_rbtree_iterator(_NodePtr current, _NodePtr nil) : _current_(current), _nil_(nil) {}
+	_rbtree_iterator(node_ptr current, node_ptr nil) : _current_(current), _nil_(nil) {}
 	_rbtree_iterator(_rbtree_iterator const& other) : _current_(other._current_), _nil_(other._nil_)
 	{}
 	_rbtree_iterator& operator=(_rbtree_iterator const& other)
@@ -148,7 +154,7 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 	}
 
 	/* -------------------------- Access operators -------------------------- */
-	_NodePtr  base() const { return _current_; }
+	node_ptr  base() const { return _current_; }
 	reference operator*() const { return _current_->_value; }
 	pointer   operator->() const { return &_current_->_value; }
 	/* ------------------------ Arithmetic operators ------------------------ */
@@ -199,8 +205,8 @@ class _rbtree
 	typedef _tree_node<value_type>  node_type;
 	typedef _tree_node<value_type>* node_pointer;
 
-	typedef _rbtree_iterator<value_type, node_pointer>       iterator;
-	typedef _rbtree_iterator<const value_type, node_pointer> const_iterator;
+	typedef _rbtree_iterator<value_type, node_type>       iterator;
+	typedef _rbtree_iterator<const value_type, node_type> const_iterator;
 
 	typedef std::size_t    size_type;
 	typedef std::ptrdiff_t difference_type;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -498,9 +498,7 @@ typename _rbtree<T, Comp, Allocator>::iterator _rbtree<T, Comp, Allocator>::eras
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::erase(iterator first, iterator last)
 {
-	int i = 0;
-	while (first != last && i < 5000) {
-		++i;
+	while (first != last) {
 		first = erase(first);
 	}
 }

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -190,6 +190,12 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 	{
 		return !(*this == other);
 	}
+
+	operator _rbtree_iterator<const T, node_type>(void) const
+	{
+		return _rbtree_iterator<const T, node_type>(_current_, _nil_);
+	}
+
 	/* ------------------------ Non-member functions ------------------------ */
 	friend bool operator==(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
 	{

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -922,6 +922,8 @@ std::string _rbtree<T, Comp, Allocator>::_node_to_dir_(
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_display(std::string func_name, int line) const
 {
+	(void)func_name;
+	(void)line;
 #ifdef DEBUG
 	std::string dirpath;
 	std::string cmd;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -138,7 +138,7 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 	_rbtree_iterator(_NodePtr current, _NodePtr nil) : _current_(current), _nil_(nil) {}
 	_rbtree_iterator(_rbtree_iterator const& other) : _current_(other._current_), _nil_(other._nil_)
 	{}
-	_rbtree_iterator operator=(_rbtree_iterator const& other)
+	_rbtree_iterator& operator=(_rbtree_iterator const& other)
 	{
 		if (this != &other) {
 			_current_ = other._current_;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -255,7 +255,6 @@ class _rbtree
 	void swap(_rbtree& other);
 
 	/* ------------------------------- Lookup ------------------------------- */
-	size_type      count(const key_type& key) const {};
 	iterator       find(const key_type& key) { return iterator(__find_equal(key), _nil); };
 	const_iterator find(const key_type& key) const
 	{

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -180,6 +180,16 @@ class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T
 		--(*this);
 		return _tmp;
 	}
+	template <class U>
+	bool operator==(const _rbtree_iterator<U, NodeType>& other) const
+	{
+		return _current_ == other.base();
+	}
+	template <class U>
+	bool operator!=(const _rbtree_iterator<U, NodeType>& other) const
+	{
+		return !(*this == other);
+	}
 	/* ------------------------ Non-member functions ------------------------ */
 	friend bool operator==(const _rbtree_iterator& _x, const _rbtree_iterator& _y)
 	{

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -62,15 +62,9 @@ bool _is_right_child_(const _NodePtr ptr)
 }
 
 template <class _NodePtr>
-bool _is_black_(
-    const _NodePtr ptr, typename ft::enable_if<!ft::is_integral<_NodePtr>::value>::type* = 0)
+bool _is_black_(const _NodePtr ptr)
 {
 	return (ptr->_is_black);
-}
-
-bool _is_black_(bool _is_black_)
-{
-	return (_is_black_);
 }
 
 template <class _NodePtr>
@@ -460,7 +454,7 @@ void _rbtree<T, Comp, Allocator>::_remove(node_pointer ptr)
 		fix_trigger_node->_is_black      = ptr->_is_black;
 	}
 
-	if (_is_black_(original_color)) {
+	if (original_color) {
 		_remove_fixup_(child_to_recolor);
 	}
 }

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -344,7 +344,12 @@ _rbtree<T, Comp, Allocator>::_rbtree(_rbtree const& other) :
     _comp(other._comp), _alloc(other._alloc), _size(0)
 {
 	_nil = _alloc.allocate(1);
-	_alloc.construct(_nil, *other._nil);
+	_alloc.construct(_nil, T());
+	_nil->_is_black = true;
+	_nil->_parent   = _nil;
+	_nil->_left     = _nil;
+	_nil->_right    = _nil;
+
 	_end = _alloc.allocate(1);
 	_alloc.construct(_end, *other._end);
 	_root  = _nil;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -658,9 +658,10 @@ void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_pointer ptr)
 {
 	node_pointer child = ptr->_left;
 	ptr->_left         = child->_right;
-	if (ptr->_right != _nil) {
-		ptr->_right->_parent = ptr;
+	if (ptr->_left != _nil) {
+		ptr->_left->_parent = ptr;
 	}
+
 	node_pointer parent = ptr->_parent;
 	child->_parent      = parent;
 	if (parent == _end) {

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -474,7 +474,8 @@ _rbtree<T, Comp, Allocator>::erase(const _Key& value)
 	}
 	if (begin() == ite) {
 		iterator next(ite);
-		_begin = ++next.base();
+		++next;
+		_begin = next.base();
 	}
 	--_size;
 	_remove(ite.base());

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -608,13 +608,11 @@ void _rbtree<T, Comp, Allocator>::_rotate_left_(const node_pointer ptr)
 	}
 	child->_left = ptr;
 	ptr->_parent = child;
-	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_pointer ptr)
 {
-	_display(__FUNCTION__, __LINE__);
 	node_pointer child = ptr->_left;
 	ptr->_left         = child->_right;
 	if (ptr->_right != _nil) {
@@ -631,7 +629,6 @@ void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_pointer ptr)
 	}
 	child->_right = ptr;
 	ptr->_parent  = child;
-	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
@@ -676,7 +673,6 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup_(node_pointer ptr)
 		}
 	}
 	_root->_is_black = true;
-	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
@@ -926,9 +922,6 @@ std::string _rbtree<T, Comp, Allocator>::_node_to_dir_(
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_display(std::string func_name, int line) const
 {
-	(void)func_name;
-	(void)line;
-#ifdef DEBUG
 	std::string dirpath;
 	std::string cmd;
 	dirpath = _node_to_dir_(_root, "./", true);

--- a/test_srcs/UnitTester.cpp
+++ b/test_srcs/UnitTester.cpp
@@ -256,7 +256,7 @@ void UnitTester::load_tests(int ac, char** av)
 	std::string              argv;
 	std::vector<std::string> lst;
 
-	for (size_t i = 1; i < ac; ++i) {
+	for (int i = 1; i < ac; ++i) {
 		argv = av[i];
 		if (argv == "vector") {
 			stl = VECTOR;


### PR DESCRIPTION
- fix #56
- add: unimplemented funcs
- delete: _is_black for bool
- delete: unused count()
- fix: suppress warnings
- fix: std::map to ft::map
- fix #57: initialize nil without copy
- fix: compile error on erase
- fix: delete erase debug
- delete: call to _display
- update: related to insert with hint (large commit)
- fix: operator= return &
- fix: iterator pass node_type not ptr
- add: rbtree iterator compare functions
- fix #58: compile error on non-const to const (ite_arror.cpp)
- fix #59: fix left right on rotate, connect parent
