### PR TITLE
feature/refactor map

### DIFF
--- a/includes/iterator_traits.hpp
+++ b/includes/iterator_traits.hpp
@@ -1,6 +1,9 @@
 #ifndef ITERATOR_TRAITS_HPP
 #define ITERATOR_TRAITS_HPP
 
+#include <iterator>
+#include <stddef.h>
+
 namespace ft {
 
 template <class Iterator>

--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -98,12 +98,12 @@ class map
 	// ------------------------------- Modifiers ------------------------------- //
 	void clear() { _tree.clear(); }
 	// insert
-	ft::pair<iterator, bool> insert(const value_type& value) { return _tree._insert(value); }
-	iterator insert(iterator hint, const value_type& value) { return _tree._insert(hint, value); }
+	ft::pair<iterator, bool> insert(const value_type& value) { return _tree.insert(value); }
+	iterator insert(iterator hint, const value_type& value) { return _tree.insert(hint, value); }
 	template <class InputIt>
 	void insert(InputIt first, InputIt last)
 	{
-		_tree._insert(first, last);
+		_tree.insert(first, last);
 	}
 	// erase
 	void      erase(iterator pos) { _tree.erase(pos); }

--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -33,20 +33,20 @@ class map
 		typedef value_type second_argument_type;
 
 		key_compare comp;
-		value_compare(key_compare c) : comp(c){};
+		value_compare(key_compare c) : comp(c) {}
 
 		bool operator()(const value_type& lhs, const value_type& rhs) const
 		{
 			return comp(lhs.first, rhs.first);
-		};
+		}
 		bool operator()(const value_type& lhs, const key_type& rhs) const
 		{
 			return comp(lhs.first, rhs);
-		};
+		}
 		bool operator()(const key_type& lhs, const value_type& rhs) const
 		{
 			return comp(lhs, rhs.first);
-		};
+		}
 	};
 
   private:
@@ -70,7 +70,7 @@ class map
 	    typename enable_if<!is_integral<InputIt>::value>::type* = 0);
 	map(map const& other);
 	// (destructor)
-	~map(){};
+	~map() {}
 	map&           operator=(map const& other);
 	allocator_type get_allocator() const { return allocator_type(_tree.get_allocator()); }
 	// ---------------------------- Elements access ---------------------------- //
@@ -78,7 +78,7 @@ class map
 	T&       at(const Key& key);
 	const T& at(const Key& key) const;
 	// operator[]
-	T& operator[](const Key& key) { return insert(ft::make_pair(key, T())).first->second; };
+	T& operator[](const Key& key) { return insert(ft::make_pair(key, T())).first->second; }
 	// ------------------------------- Iterators ------------------------------- //
 	iterator               begin() { return _tree.begin(); }
 	const_iterator         begin() const { return _tree.begin(); }
@@ -95,32 +95,32 @@ class map
 	/* ------------------------------- Modifiers ------------------------------- */
 	void clear() { _tree.clear(); }
 	// insert
-	ft::pair<iterator, bool> insert(const value_type& value) { return _tree._insert(value); };
-	iterator insert(iterator hint, const value_type& value) { return _tree._insert(hint, value); };
+	ft::pair<iterator, bool> insert(const value_type& value) { return _tree._insert(value); }
+	iterator insert(iterator hint, const value_type& value) { return _tree._insert(hint, value); }
 	template <class InputIt>
 	void insert(InputIt first, InputIt last)
 	{
 		_tree._insert(first, last);
 	}
 	// erase
-	void      erase(iterator pos) { _tree.erase(pos); };
-	void      erase(iterator first, iterator last) { _tree.erase(first, last); };
-	size_type erase(const Key& key) { return _tree.erase(key); };
+	void      erase(iterator pos) { _tree.erase(pos); }
+	void      erase(iterator first, iterator last) { _tree.erase(first, last); }
+	size_type erase(const Key& key) { return _tree.erase(key); }
 	// swap
-	void swap(map& other) { _tree.swap(other._tree); };
+	void swap(map& other) { _tree.swap(other._tree); }
 	/* --------------------------------- Lookup -------------------------------- */
 	size_type                count(const Key& key) const { return (find(key) == end() ? 0 : 1); }
-	iterator                 find(const Key& key) { return _tree.find(key); };
-	const_iterator           find(const Key& key) const { return _tree.find(key); };
+	iterator                 find(const Key& key) { return _tree.find(key); }
+	const_iterator           find(const Key& key) const { return _tree.find(key); }
 	pair<iterator, iterator> equal_range(const Key& key) { return _tree.equal_range(key); }
 	pair<const_iterator, const_iterator> equal_range(const Key& key) const
 	{
 		return _tree.equal_range(key);
 	}
-	iterator       lower_bound(const Key& key) { return _tree.lower_bound(key); };
-	const_iterator lower_bound(const Key& key) const { return _tree.lower_bound(key); };
-	iterator       upper_bound(const Key& key) { return _tree.upper_bound(key); };
-	const_iterator upper_bound(const Key& key) const { return _tree.upper_bound(key); };
+	iterator       lower_bound(const Key& key) { return _tree.lower_bound(key); }
+	const_iterator lower_bound(const Key& key) const { return _tree.lower_bound(key); }
+	iterator       upper_bound(const Key& key) { return _tree.upper_bound(key); }
+	const_iterator upper_bound(const Key& key) const { return _tree.upper_bound(key); }
 	/* ------------------------------- Observers ------------------------------- */
 	key_compare   key_comp() const { return _key_comp; }
 	value_compare value_comp() const { return _value_comp; }

--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -79,6 +79,7 @@ class map
 	const T& at(const Key& key) const;
 	// operator[]
 	T& operator[](const Key& key) { return insert(ft::make_pair(key, T())).first->second; }
+
 	// ------------------------------- Iterators ------------------------------- //
 	iterator               begin() { return _tree.begin(); }
 	const_iterator         begin() const { return _tree.begin(); }
@@ -88,11 +89,13 @@ class map
 	const_reverse_iterator rbegin() const { return reverse_iterator(end()); }
 	reverse_iterator       rend() { return reverse_iterator(begin()); }
 	const_reverse_iterator rend() const { return reverse_iterator(begin()); }
-	/* -------------------------------- Capacity ------------------------------- */
+
+	// -------------------------------- Capacity ------------------------------- //
 	bool      empty() const { return _tree.empty(); }
 	size_type size() const { return _tree.size(); }
 	size_type max_size() const { return _tree.max_size(); }
-	/* ------------------------------- Modifiers ------------------------------- */
+
+	// ------------------------------- Modifiers ------------------------------- //
 	void clear() { _tree.clear(); }
 	// insert
 	ft::pair<iterator, bool> insert(const value_type& value) { return _tree._insert(value); }
@@ -108,7 +111,8 @@ class map
 	size_type erase(const Key& key) { return _tree.erase(key); }
 	// swap
 	void swap(map& other) { _tree.swap(other._tree); }
-	/* --------------------------------- Lookup -------------------------------- */
+
+	// --------------------------------- Lookup -------------------------------- //
 	size_type                count(const Key& key) const { return (find(key) == end() ? 0 : 1); }
 	iterator                 find(const Key& key) { return _tree.find(key); }
 	const_iterator           find(const Key& key) const { return _tree.find(key); }
@@ -121,7 +125,7 @@ class map
 	const_iterator lower_bound(const Key& key) const { return _tree.lower_bound(key); }
 	iterator       upper_bound(const Key& key) { return _tree.upper_bound(key); }
 	const_iterator upper_bound(const Key& key) const { return _tree.upper_bound(key); }
-	/* ------------------------------- Observers ------------------------------- */
+	// ------------------------------- Observers ------------------------------- //
 	key_compare   key_comp() const { return _key_comp; }
 	value_compare value_comp() const { return _value_comp; }
 };

--- a/includes/map.hpp
+++ b/includes/map.hpp
@@ -105,7 +105,7 @@ class map
 	// erase
 	void      erase(iterator pos) { _tree.erase(pos); };
 	void      erase(iterator first, iterator last) { _tree.erase(first, last); };
-	size_type erase(const Key& key) { _tree.erase(key); };
+	size_type erase(const Key& key) { return _tree.erase(key); };
 	// swap
 	void swap(map& other) { _tree.swap(other._tree); };
 	/* --------------------------------- Lookup -------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -15,9 +15,7 @@ namespace ft {
 /*                                  Tree Node                                 */
 /* -------------------------------------------------------------------------- */
 template <class T>
-class _tree_node
-{
-  public:
+struct _tree_node {
 	_tree_node* _parent;
 	_tree_node* _right;
 	_tree_node* _left;
@@ -34,7 +32,7 @@ class _tree_node
 	{}
 	_tree_node& operator=(_tree_node const& other)
 	{
-		if (*this != other) {
+		if (this != &other) {
 			_left     = other._left;
 			_right    = other._right;
 			_parent   = other._parent;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -316,10 +316,10 @@ class _rbtree
 
 	node_ptr _find_insert_position(const value_type& value, node_ptr hint = NULL);
 	node_ptr _insert_unique(const value_type& value, node_ptr parent);
-	void     _insert_fixup_(node_ptr ptr);
+	void     _insert_fixup(node_ptr ptr);
 	void     _insert_update(const node_ptr new_);
 	void     _remove(node_ptr ptr);
-	void     _remove_fixup_(node_ptr ptr);
+	void     _remove_fixup(node_ptr ptr);
 
 	// ------------------------------- Lookup ------------------------------- //
 	template <class _Key>
@@ -647,13 +647,13 @@ _rbtree<T, Comp, Allocator>::_insert_unique(const value_type& value, node_ptr pa
 		parent->_right = new_;
 	}
 	new_->_parent = parent;
-	_insert_fixup_(new_);
+	_insert_fixup(new_);
 	_insert_update(new_);
 	return new_;
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_insert_fixup_(node_ptr ptr)
+void _rbtree<T, Comp, Allocator>::_insert_fixup(node_ptr ptr)
 {
 	node_ptr uncle;
 	while (_is_red_(ptr->_parent)) {
@@ -737,12 +737,12 @@ void _rbtree<T, Comp, Allocator>::_remove(node_ptr ptr)
 	}
 
 	if (original_color) {
-		_remove_fixup_(child_to_recolor);
+		_remove_fixup(child_to_recolor);
 	}
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_ptr ptr)
+void _rbtree<T, Comp, Allocator>::_remove_fixup(node_ptr ptr)
 {
 	node_ptr brother;
 

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -323,8 +323,6 @@ class _rbtree
 
 	// ------------------------------- Lookup ------------------------------- //
 	template <class _Key>
-	iterator _find(const _Key& value) const;
-	template <class _Key>
 	pair<iterator, iterator> __equal_range_unique(const _Key& key);
 	template <class _Key>
 	pair<const_iterator, const_iterator> __equal_range_unique(const _Key& key) const;
@@ -443,7 +441,7 @@ template <class _Key>
 typename _rbtree<T, Comp, Allocator>::size_type
 _rbtree<T, Comp, Allocator>::erase(const _Key& value)
 {
-	iterator ite = _find(value);
+	iterator ite(__find_equal(value), _nil);
 	if (ite == end()) {
 		return 0;
 	}
@@ -600,7 +598,6 @@ void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_ptr ptr)
 }
 
 /* --------------------------------- _insert -------------------------------- */
-
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_ptr
 _rbtree<T, Comp, Allocator>::_find_insert_position(const value_type& value, node_ptr hint)
@@ -709,7 +706,6 @@ void _rbtree<T, Comp, Allocator>::_insert_update(const node_ptr new_)
 }
 
 /* --------------------------------- _remove -------------------------------- */
-
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_remove(node_ptr ptr)
 {
@@ -807,13 +803,6 @@ void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_ptr ptr)
 /* -------------------------------------------------------------------------- */
 /*                                   Lookups                                  */
 /* -------------------------------------------------------------------------- */
-template <class T, class Comp, class Allocator>
-template <class _Key>
-typename _rbtree<T, Comp, Allocator>::iterator
-_rbtree<T, Comp, Allocator>::_find(const _Key& key) const
-{
-	return iterator(__find_equal(key), _nil);
-}
 
 template <class T, class Comp, class Allocator>
 template <class _Key>

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -221,7 +221,7 @@ class _rbtree
 	typedef Comp                    value_compare;
 	typedef Allocator               allocator_type;
 	typedef _tree_node<value_type>  node_type;
-	typedef _tree_node<value_type>* node_pointer;
+	typedef _tree_node<value_type>* node_ptr;
 
 	typedef _rbtree_iterator<value_type, node_type>       iterator;
 	typedef _rbtree_iterator<const value_type, node_type> const_iterator;
@@ -233,9 +233,9 @@ class _rbtree
 	typedef std::allocator_traits<node_allocator>                 node_traits;
 
   private:
-	node_pointer   _nil;
-	node_pointer   _begin;
-	node_pointer   _end;
+	node_ptr       _nil;
+	node_ptr       _begin;
+	node_ptr       _end;
 	value_compare  _comp;
 	node_allocator _alloc;
 	size_type      _size;
@@ -274,7 +274,7 @@ class _rbtree
 	void                     clear();
 	ft::pair<iterator, bool> _insert(const value_type& value);
 	iterator                 _insert(iterator hint, const value_type& value);
-	node_pointer             _insert_unique(const value_type& value, node_pointer parent);
+	node_ptr                 _insert_unique(const value_type& value, node_ptr parent);
 	template <class InputIt>
 	void _insert(InputIt first, InputIt last);
 	void swap(_rbtree& other);
@@ -302,22 +302,22 @@ class _rbtree
 	}
 
   private:
-	node_pointer _root() const;
-	node_pointer _init_tree_node_(const value_type& value);
-	void         _insert_update(const node_pointer new_);
-	node_pointer _find_insert_position(const value_type& value, node_pointer hint = NULL);
-	void         _set_root(const node_pointer ptr);
-	void         _remove(node_pointer ptr);
+	node_ptr _root() const;
+	node_ptr _init_tree_node_(const value_type& value);
+	void     _insert_update(const node_ptr new_);
+	node_ptr _find_insert_position(const value_type& value, node_ptr hint = NULL);
+	void     _set_root(const node_ptr ptr);
+	void     _remove(node_ptr ptr);
 
-	void _destroy_recursive(node_pointer ptr);
-	void _destroy_one(node_pointer ptr);
+	void _destroy_recursive(node_ptr ptr);
+	void _destroy_one(node_ptr ptr);
 
 	/* ----------------------------- algorithms ----------------------------- */
-	void _transplant_(node_pointer old_ptr, node_pointer new_ptr);
-	void _rotate_left_(node_pointer ptr);
-	void _rotate_right_(node_pointer ptr);
-	void _insert_fixup_(node_pointer ptr);
-	void _remove_fixup_(node_pointer ptr);
+	void _transplant_(node_ptr old_ptr, node_ptr new_ptr);
+	void _rotate_left_(node_ptr ptr);
+	void _rotate_right_(node_ptr ptr);
+	void _insert_fixup_(node_ptr ptr);
+	void _remove_fixup_(node_ptr ptr);
 
 	/* ------------------------------- Lookup ------------------------------- */
 	template <class _Key>
@@ -325,15 +325,14 @@ class _rbtree
 	template <class _Key>
 	pair<const_iterator, const_iterator> __equal_range_unique(const _Key& key) const;
 	template <class _Key>
-	node_pointer __find_equal(const _Key& key) const;
-	node_pointer __lower_bound(const key_type& key) const;
-	node_pointer __upper_bound(const key_type& key) const;
+	node_ptr __find_equal(const _Key& key) const;
+	node_ptr __lower_bound(const key_type& key) const;
+	node_ptr __upper_bound(const key_type& key) const;
 
 	/* -------------------------------- debug ------------------------------- */
-	int  _check_tree_recursive_(node_pointer ptr, int black_count, int& invalid) const;
-	void _check_tree_validity_() const;
-	std::string
-	_node_to_dir_(const node_pointer& value, std::string dirprefix, bool is_right) const;
+	int         _check_tree_recursive_(node_ptr ptr, int black_count, int& invalid) const;
+	void        _check_tree_validity_() const;
+	std::string _node_to_dir_(const node_ptr& value, std::string dirprefix, bool is_right) const;
 };
 
 /* -------------------------------------------------------------------------- */
@@ -390,10 +389,10 @@ _rbtree<T, Comp, Allocator>& _rbtree<T, Comp, Allocator>::operator=(_rbtree cons
 }
 
 template <class T, class Comp, class Allocator>
-typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_insert_unique(const value_type& value, node_pointer parent)
+typename _rbtree<T, Comp, Allocator>::node_ptr
+_rbtree<T, Comp, Allocator>::_insert_unique(const value_type& value, node_ptr parent)
 {
-	node_pointer new_ = _init_tree_node_(value);
+	node_ptr new_ = _init_tree_node_(value);
 
 	if (parent == _end) {
 		_set_root(new_);
@@ -419,7 +418,7 @@ template <class T, class Comp, class Allocator>
 typename ft::pair<typename _rbtree<T, Comp, Allocator>::iterator, bool>
 _rbtree<T, Comp, Allocator>::_insert(const value_type& value)
 {
-	node_pointer ptr = _find_insert_position(value);
+	node_ptr ptr = _find_insert_position(value);
 	if (ptr != _end && !_comp(ptr->_value, value) && !_comp(value, ptr->_value)) {
 		return ft::make_pair(iterator(ptr, _nil), false);
 	}
@@ -430,7 +429,7 @@ template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::iterator
 _rbtree<T, Comp, Allocator>::_insert(iterator hint, const value_type& value)
 {
-	node_pointer ptr = _find_insert_position(value, hint.base());
+	node_ptr ptr = _find_insert_position(value, hint.base());
 	if (ptr != _end && !_comp(ptr->_value, value) && !_comp(value, ptr->_value)) {
 		return iterator(ptr, _nil);
 	}
@@ -466,11 +465,11 @@ _rbtree<T, Comp, Allocator>::_find(const _Key& key) const
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_remove(node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_remove(node_ptr ptr)
 {
-	node_pointer fix_trigger_node = ptr;
-	node_pointer child_to_recolor;
-	bool         original_color = _is_black_(fix_trigger_node);
+	node_ptr fix_trigger_node = ptr;
+	node_ptr child_to_recolor;
+	bool     original_color = _is_black_(fix_trigger_node);
 
 	if (ptr->_left == _nil) {
 		child_to_recolor = ptr->_right;
@@ -545,16 +544,16 @@ void _rbtree<T, Comp, Allocator>::erase(iterator first, iterator last)
 /* -------------------------------------------------------------------------- */
 
 template <class T, class Comp, class Allocator>
-typename _rbtree<T, Comp, Allocator>::node_pointer _rbtree<T, Comp, Allocator>::_root() const
+typename _rbtree<T, Comp, Allocator>::node_ptr _rbtree<T, Comp, Allocator>::_root() const
 {
 	return _end->_left;
 }
 
 template <class T, class Comp, class Allocator>
-typename _rbtree<T, Comp, Allocator>::node_pointer
+typename _rbtree<T, Comp, Allocator>::node_ptr
 _rbtree<T, Comp, Allocator>::_init_tree_node_(const value_type& value)
 {
-	node_pointer ptr = _alloc.allocate(1);
+	node_ptr ptr = _alloc.allocate(1);
 	_alloc.construct(ptr, value);
 	ptr->_parent   = _nil;
 	ptr->_right    = _nil;
@@ -564,7 +563,7 @@ _rbtree<T, Comp, Allocator>::_init_tree_node_(const value_type& value)
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_insert_update(const node_pointer new_)
+void _rbtree<T, Comp, Allocator>::_insert_update(const node_ptr new_)
 {
 	if (_begin == _end || _comp(new_->_value, _begin->_value)) {
 		_begin = new_;
@@ -573,11 +572,11 @@ void _rbtree<T, Comp, Allocator>::_insert_update(const node_pointer new_)
 }
 
 template <class T, class Comp, class Allocator>
-typename _rbtree<T, Comp, Allocator>::node_pointer
-_rbtree<T, Comp, Allocator>::_find_insert_position(const value_type& value, node_pointer hint)
+typename _rbtree<T, Comp, Allocator>::node_ptr
+_rbtree<T, Comp, Allocator>::_find_insert_position(const value_type& value, node_ptr hint)
 {
-	node_pointer prev    = _end;
-	node_pointer current = _root();
+	node_ptr prev    = _end;
+	node_ptr current = _root();
 
 	if (hint && hint != _end) {
 		if (_comp(value, hint->_value) && hint->_left == _nil) {
@@ -608,14 +607,14 @@ _rbtree<T, Comp, Allocator>::_find_insert_position(const value_type& value, node
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_set_root(const node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_set_root(const node_ptr ptr)
 {
 	ptr->_parent = _end;
 	_end->_left  = ptr;
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_destroy_recursive(node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_destroy_recursive(node_ptr ptr)
 {
 	if (ptr == _nil)
 		return;
@@ -625,7 +624,7 @@ void _rbtree<T, Comp, Allocator>::_destroy_recursive(node_pointer ptr)
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_destroy_one(node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_destroy_one(node_ptr ptr)
 {
 	_alloc.destroy(ptr);
 	_alloc.deallocate(ptr, 1);
@@ -636,7 +635,7 @@ void _rbtree<T, Comp, Allocator>::_destroy_one(node_pointer ptr)
 /* -------------------------------------------------------------------------- */
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_transplant_(node_pointer old_ptr, node_pointer new_ptr)
+void _rbtree<T, Comp, Allocator>::_transplant_(node_ptr old_ptr, node_ptr new_ptr)
 {
 	if (old_ptr->_parent == _end) {
 		_set_root(new_ptr);
@@ -649,16 +648,16 @@ void _rbtree<T, Comp, Allocator>::_transplant_(node_pointer old_ptr, node_pointe
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_rotate_left_(const node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_rotate_left_(const node_ptr ptr)
 {
-	node_pointer child = ptr->_right;
-	ptr->_right        = child->_left;
+	node_ptr child = ptr->_right;
+	ptr->_right    = child->_left;
 	if (ptr->_right != _nil) {
 		ptr->_right->_parent = ptr;
 	}
 
-	node_pointer parent = ptr->_parent;
-	child->_parent      = parent;
+	node_ptr parent = ptr->_parent;
+	child->_parent  = parent;
 	if (parent == _end) {
 		_set_root(child);
 	} else if (_is_left_child_(ptr)) {
@@ -671,16 +670,16 @@ void _rbtree<T, Comp, Allocator>::_rotate_left_(const node_pointer ptr)
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_ptr ptr)
 {
-	node_pointer child = ptr->_left;
-	ptr->_left         = child->_right;
+	node_ptr child = ptr->_left;
+	ptr->_left     = child->_right;
 	if (ptr->_left != _nil) {
 		ptr->_left->_parent = ptr;
 	}
 
-	node_pointer parent = ptr->_parent;
-	child->_parent      = parent;
+	node_ptr parent = ptr->_parent;
+	child->_parent  = parent;
 	if (parent == _end) {
 		_set_root(child);
 	} else if (_is_left_child_(ptr)) {
@@ -693,9 +692,9 @@ void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_pointer ptr)
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_insert_fixup_(node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_insert_fixup_(node_ptr ptr)
 {
-	node_pointer uncle;
+	node_ptr uncle;
 	while (_is_red_(ptr->_parent)) {
 		if (_is_left_child_(ptr->_parent)) {
 			uncle = ptr->_parent->_parent->_right;
@@ -737,9 +736,9 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup_(node_pointer ptr)
 }
 
 template <class T, class Comp, class Allocator>
-void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_pointer ptr)
+void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_ptr ptr)
 {
-	node_pointer brother;
+	node_ptr brother;
 
 	while (ptr != _root() && _is_black_(ptr)) {
 		if (_is_left_child_(ptr)) {
@@ -801,10 +800,10 @@ void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_pointer ptr)
 
 template <class T, class Comp, class Allocator>
 template <class _Key>
-typename _rbtree<T, Comp, Allocator>::node_pointer
+typename _rbtree<T, Comp, Allocator>::node_ptr
 _rbtree<T, Comp, Allocator>::__find_equal(const _Key& key) const
 {
-	node_pointer ptr = _root();
+	node_ptr ptr = _root();
 
 	while (ptr != _nil) {
 		if (_comp(key, ptr->_value)) {
@@ -824,8 +823,8 @@ ft::pair<typename _rbtree<T, Comp, Allocator>::iterator,
     typename _rbtree<T, Comp, Allocator>::iterator>
 _rbtree<T, Comp, Allocator>::__equal_range_unique(const _Key& key)
 {
-	node_pointer ptr    = _root();
-	node_pointer result = _end;
+	node_ptr ptr    = _root();
+	node_ptr result = _end;
 
 	while (ptr != _nil) {
 		if (_comp(key, ptr->_value)) {
@@ -849,8 +848,8 @@ ft::pair<typename _rbtree<T, Comp, Allocator>::const_iterator,
     typename _rbtree<T, Comp, Allocator>::const_iterator>
 _rbtree<T, Comp, Allocator>::__equal_range_unique(const _Key& key) const
 {
-	node_pointer ptr    = _root();
-	node_pointer result = _end;
+	node_ptr ptr    = _root();
+	node_ptr result = _end;
 
 	while (ptr != _nil) {
 		if (_comp(key, ptr->_value)) {
@@ -869,11 +868,11 @@ _rbtree<T, Comp, Allocator>::__equal_range_unique(const _Key& key) const
 }
 
 template <class T, class Comp, class Allocator>
-typename _rbtree<T, Comp, Allocator>::node_pointer
+typename _rbtree<T, Comp, Allocator>::node_ptr
 _rbtree<T, Comp, Allocator>::__lower_bound(const key_type& key) const
 {
-	node_pointer ptr    = _root();
-	node_pointer result = _end;
+	node_ptr ptr    = _root();
+	node_ptr result = _end;
 
 	while (ptr != _nil) {
 		if (!_comp(ptr->_value, key)) {
@@ -887,11 +886,11 @@ _rbtree<T, Comp, Allocator>::__lower_bound(const key_type& key) const
 }
 
 template <class T, class Comp, class Allocator>
-typename _rbtree<T, Comp, Allocator>::node_pointer
+typename _rbtree<T, Comp, Allocator>::node_ptr
 _rbtree<T, Comp, Allocator>::__upper_bound(const key_type& key) const
 {
-	node_pointer ptr    = _root();
-	node_pointer result = _end;
+	node_ptr ptr    = _root();
+	node_ptr result = _end;
 
 	while (ptr != _nil) {
 		if (_comp(key, ptr->_value)) {
@@ -910,7 +909,7 @@ _rbtree<T, Comp, Allocator>::__upper_bound(const key_type& key) const
 
 template <class T, class Comp, class Allocator>
 int _rbtree<T, Comp, Allocator>::_check_tree_recursive_(
-    node_pointer ptr, int black_counts, int& invalid) const
+    node_ptr ptr, int black_counts, int& invalid) const
 {
 	if (ptr == _nil) {
 		return black_counts;
@@ -939,7 +938,7 @@ void _rbtree<T, Comp, Allocator>::_check_tree_validity_() const
 		std::cerr << "2. root must be black" << std::endl;
 		++invalid;
 	}
-	node_pointer ptr = _root();
+	node_ptr ptr = _root();
 	_check_tree_recursive_(ptr, 0, invalid);
 	if (invalid) {
 		std::cerr << "\033[31m"
@@ -955,7 +954,7 @@ void _rbtree<T, Comp, Allocator>::_check_tree_validity_() const
 
 template <class T, class Comp, class Allocator>
 std::string _rbtree<T, Comp, Allocator>::_node_to_dir_(
-    const node_pointer& v, std::string dirprefix, bool is_right) const
+    const node_ptr& v, std::string dirprefix, bool is_right) const
 {
 	if (v == _nil)
 		return "";

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -317,6 +317,8 @@ class _rbtree
 	node_ptr _find_insert_position(const value_type& value, node_ptr hint = NULL);
 	node_ptr _insert_unique(const value_type& value, node_ptr parent);
 	void     _insert_fixup(node_ptr ptr);
+	void     _insert_fixup_left(node_ptr& ptr);
+	void     _insert_fixup_right(node_ptr& ptr);
 	void     _insert_update(const node_ptr new_);
 	void     _remove(node_ptr ptr);
 	void     _remove_fixup(node_ptr ptr);
@@ -657,45 +659,56 @@ _rbtree<T, Comp, Allocator>::_insert_unique(const value_type& value, node_ptr pa
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_insert_fixup(node_ptr ptr)
 {
-	node_ptr uncle;
 	while (_is_red_(ptr->_parent)) {
 		if (_is_left_child_(ptr->_parent)) {
-			uncle = ptr->_parent->_parent->_right;
-			if (_is_red_(uncle)) {
-				ptr->_parent->_is_black   = true;
-				uncle->_is_black          = true;
-				uncle->_parent->_is_black = false;
-
-				ptr = uncle->_parent;
-			} else {
-				if (_is_right_child_(ptr)) {
-					ptr = ptr->_parent;
-					_rotate_left_(ptr);
-				}
-				ptr->_parent->_is_black          = true;
-				ptr->_parent->_parent->_is_black = false;
-				_rotate_right_(ptr->_parent->_parent);
-			}
+			_insert_fixup_left(ptr);
 		} else {
-			uncle = ptr->_parent->_parent->_left;
-			if (_is_red_(uncle)) {
-				ptr->_parent->_is_black   = true;
-				uncle->_is_black          = true;
-				uncle->_parent->_is_black = false;
-
-				ptr = uncle->_parent;
-			} else {
-				if (_is_left_child_(ptr)) {
-					ptr = ptr->_parent;
-					_rotate_right_(ptr);
-				}
-				ptr->_parent->_is_black          = true;
-				ptr->_parent->_parent->_is_black = false;
-				_rotate_left_(ptr->_parent->_parent);
-			}
+			_insert_fixup_right(ptr);
 		}
 	}
 	_root()->_is_black = true;
+}
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_insert_fixup_left(node_ptr& ptr)
+{
+	node_ptr uncle = ptr->_parent->_parent->_right;
+	if (_is_red_(uncle)) {
+		ptr->_parent->_is_black   = true;
+		uncle->_is_black          = true;
+		uncle->_parent->_is_black = false;
+
+		ptr = uncle->_parent;
+	} else {
+		if (_is_right_child_(ptr)) {
+			ptr = ptr->_parent;
+			_rotate_left_(ptr);
+		}
+		ptr->_parent->_is_black          = true;
+		ptr->_parent->_parent->_is_black = false;
+		_rotate_right_(ptr->_parent->_parent);
+	}
+}
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_insert_fixup_right(node_ptr& ptr)
+{
+	node_ptr uncle = ptr->_parent->_parent->_left;
+	if (_is_red_(uncle)) {
+		ptr->_parent->_is_black   = true;
+		uncle->_is_black          = true;
+		uncle->_parent->_is_black = false;
+
+		ptr = uncle->_parent;
+	} else {
+		if (_is_left_child_(ptr)) {
+			ptr = ptr->_parent;
+			_rotate_right_(ptr);
+		}
+		ptr->_parent->_is_black          = true;
+		ptr->_parent->_parent->_is_black = false;
+		_rotate_left_(ptr->_parent->_parent);
+	}
 }
 
 template <class T, class Comp, class Allocator>

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -209,7 +209,6 @@ class _rbtree
 	typedef std::allocator_traits<node_allocator>                 node_traits;
 
   private:
-	node_pointer   _root;
 	node_pointer   _nil;
 	node_pointer   _begin;
 	node_pointer   _end;
@@ -239,7 +238,7 @@ class _rbtree
 	const_iterator end() const { return const_iterator(_end, _nil); }
 
 	/* ------------------------------ Capacity ------------------------------ */
-	bool      empty() const { return _root == _nil; }
+	bool      empty() const { return _root() == _nil; }
 	size_type size() const { return _size; };
 	size_type max_size() const
 	{
@@ -277,6 +276,7 @@ class _rbtree
 	}
 
   private:
+	node_pointer _root() const;
 	node_pointer _init_tree_node_(const value_type& value);
 	void         _insert_update(const node_pointer new_);
 	node_pointer _find_insert_position(const value_type& value);
@@ -325,7 +325,6 @@ _rbtree<T, Comp, Allocator>::_rbtree(const Comp& comp, const Allocator& alloc) :
 	_nil->_left     = _nil;
 	_nil->_right    = _nil;
 
-	_root           = _nil;
 	_end            = _init_tree_node_(T());
 	_end->_is_black = true;
 	_begin          = _end;
@@ -334,8 +333,7 @@ _rbtree<T, Comp, Allocator>::_rbtree(const Comp& comp, const Allocator& alloc) :
 template <class T, class Comp, class Allocator>
 _rbtree<T, Comp, Allocator>::~_rbtree()
 {
-	_destroy_recursive(_root);
-	_destroy_one(_end);
+	_destroy_recursive(_end);
 	_destroy_one(_nil);
 }
 
@@ -345,9 +343,7 @@ _rbtree<T, Comp, Allocator>::_rbtree(_rbtree const& other) :
 {
 	_nil = _alloc.allocate(1);
 	_alloc.construct(_nil, *other._nil);
-	_end = _alloc.allocate(1);
-	_alloc.construct(_end, *other._end);
-	_root  = _nil;
+	_end   = _init_tree_node_(T());
 	_begin = _end;
 	_insert(other.begin(), other.end());
 }
@@ -405,7 +401,6 @@ void _rbtree<T, Comp, Allocator>::_insert(InputIt first, InputIt last)
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::swap(_rbtree& other)
 {
-	std::swap(_root, other._root);
 	std::swap(_nil, other._nil);
 	std::swap(_begin, other._begin);
 	std::swap(_end, other._end);
@@ -504,6 +499,12 @@ void _rbtree<T, Comp, Allocator>::erase(iterator first, iterator last)
 /* -------------------------------------------------------------------------- */
 
 template <class T, class Comp, class Allocator>
+typename _rbtree<T, Comp, Allocator>::node_pointer _rbtree<T, Comp, Allocator>::_root() const
+{
+	return _end->_left;
+}
+
+template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::_init_tree_node_(const value_type& value)
 {
@@ -531,7 +532,7 @@ _rbtree<T, Comp, Allocator>::_find_insert_position(const value_type& value)
 {
 	node_pointer prev = _end;
 
-	for (node_pointer current = _root; current != _nil;) {
+	for (node_pointer current = _root(); current != _nil;) {
 		prev = current;
 		if (_comp(value, current->_value)) {
 			current = current->_left;
@@ -545,9 +546,8 @@ _rbtree<T, Comp, Allocator>::_find_insert_position(const value_type& value)
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_set_root(const node_pointer ptr)
 {
-	_root          = ptr;
-	_root->_parent = _end;
-	_end->_left    = _root;
+	ptr->_parent = _end;
+	_end->_left  = ptr;
 }
 
 template <class T, class Comp, class Allocator>
@@ -668,7 +668,7 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup_(node_pointer ptr)
 			}
 		}
 	}
-	_root->_is_black = true;
+	_root()->_is_black = true;
 }
 
 template <class T, class Comp, class Allocator>
@@ -676,7 +676,7 @@ void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_pointer ptr)
 {
 	node_pointer cousin;
 
-	while (ptr != _root && _is_black_(ptr)) {
+	while (ptr != _root() && _is_black_(ptr)) {
 		if (_is_left_child_(ptr)) {
 			cousin = ptr->_parent->_right;
 			if (_is_red_(cousin)) {
@@ -699,7 +699,7 @@ void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_pointer ptr)
 				ptr->_parent->_is_black   = true;
 				cousin->_right->_is_black = true;
 				_rotate_left_(ptr->_parent);
-				ptr = _root;
+				ptr = _root();
 			}
 		} else {
 			cousin = ptr->_parent->_left;
@@ -723,7 +723,7 @@ void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_pointer ptr)
 				ptr->_parent->_is_black  = true;
 				cousin->_left->_is_black = true;
 				_rotate_right_(ptr->_parent);
-				ptr = _root;
+				ptr = _root();
 			}
 		}
 	}
@@ -739,7 +739,7 @@ template <class _Key>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::__find_equal(const _Key& key) const
 {
-	node_pointer ptr = _root;
+	node_pointer ptr = _root();
 
 	while (ptr != _nil) {
 		if (_comp(key, ptr->_value)) {
@@ -759,7 +759,7 @@ ft::pair<typename _rbtree<T, Comp, Allocator>::iterator,
     typename _rbtree<T, Comp, Allocator>::iterator>
 _rbtree<T, Comp, Allocator>::__equal_range_unique(const _Key& key)
 {
-	node_pointer ptr    = _root;
+	node_pointer ptr    = _root();
 	node_pointer result = _end;
 
 	while (ptr != _nil) {
@@ -784,7 +784,7 @@ ft::pair<typename _rbtree<T, Comp, Allocator>::const_iterator,
     typename _rbtree<T, Comp, Allocator>::const_iterator>
 _rbtree<T, Comp, Allocator>::__equal_range_unique(const _Key& key) const
 {
-	node_pointer ptr    = _root;
+	node_pointer ptr    = _root();
 	node_pointer result = _end;
 
 	while (ptr != _nil) {
@@ -807,7 +807,7 @@ template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::__lower_bound(const key_type& key) const
 {
-	node_pointer ptr    = _root;
+	node_pointer ptr    = _root();
 	node_pointer result = _end;
 
 	while (ptr != _nil) {
@@ -825,7 +825,7 @@ template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::__upper_bound(const key_type& key) const
 {
-	node_pointer ptr    = _root;
+	node_pointer ptr    = _root();
 	node_pointer result = _end;
 
 	while (ptr != _nil) {
@@ -870,11 +870,11 @@ template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_check_tree_validity_() const
 {
 	int invalid = 0;
-	if (_is_red_(_root)) {
+	if (_is_red_(_root())) {
 		std::cerr << "2. root must be black" << std::endl;
 		++invalid;
 	}
-	node_pointer ptr = _root;
+	node_pointer ptr = _root();
 	_check_tree_recursive_(ptr, 0, invalid);
 	if (invalid) {
 		std::cerr << "\033[31m"
@@ -923,7 +923,7 @@ void _rbtree<T, Comp, Allocator>::_display(std::string func_name, int line) cons
 #ifdef DEBUG
 	std::string dirpath;
 	std::string cmd;
-	dirpath = _node_to_dir_(_root, "./", true);
+	dirpath = _node_to_dir_(_root(), "./", true);
 	std::cerr << "size: " << _size << std::endl;
 
 	std::cerr << __FILE__ << ":" << line << " (" << func_name << ")" << std::endl;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -121,7 +121,7 @@ _NodePtr _tree_prev_(_NodePtr ptr, _NodePtr _nil)
 /*                               RBtree Iterator                              */
 /* -------------------------------------------------------------------------- */
 template <class T, class NodeType>
-class _rbtree_iterator : public std::iterator<std::bidirectional_iterator_tag, T>
+class _rbtree_iterator
 {
   public:
 	typedef NodeType*                                                  iterator_type;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -320,6 +320,8 @@ class _rbtree
 	void     _insert_update(const node_ptr new_);
 	void     _remove(node_ptr ptr);
 	void     _remove_fixup(node_ptr ptr);
+	void     _remove_fixup_left(node_ptr& ptr);
+	void     _remove_fixup_right(node_ptr& ptr);
 
 	// ------------------------------- Lookup ------------------------------- //
 	template <class _Key>
@@ -744,60 +746,70 @@ void _rbtree<T, Comp, Allocator>::_remove(node_ptr ptr)
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_remove_fixup(node_ptr ptr)
 {
-	node_ptr brother;
-
 	while (ptr != _root() && _is_black_(ptr)) {
 		if (_is_left_child_(ptr)) {
-			brother = ptr->_parent->_right;
-			if (_is_red_(brother)) {
-				brother->_is_black      = true;
-				ptr->_parent->_is_black = false;
-				_rotate_left_(ptr->_parent);
-				brother = ptr->_parent->_right;
-			}
-			if (_is_black_(brother->_left) && _is_black_(brother->_right)) {
-				brother->_is_black = false;
-				ptr                = ptr->_parent;
-			} else if (_is_black_(brother->_right)) {
-				brother->_left->_is_black = true;
-				brother->_is_black        = false;
-				_rotate_right_(brother);
-				brother = ptr->_parent->_right;
-			}
-			if (_is_red_(brother->_right)) {
-				brother->_is_black         = ptr->_parent->_is_black;
-				ptr->_parent->_is_black    = true;
-				brother->_right->_is_black = true;
-				_rotate_left_(ptr->_parent);
-				ptr = _root();
-			}
+			_remove_fixup_left(ptr);
 		} else {
-			brother = ptr->_parent->_left;
-			if (_is_red_(brother)) {
-				brother->_is_black      = true;
-				ptr->_parent->_is_black = false;
-				_rotate_left_(ptr->_parent);
-				brother = ptr->_parent->_left;
-			}
-			if (_is_black_(brother->_right) && _is_black_(brother->_left)) {
-				brother->_is_black = false;
-				ptr                = ptr->_parent;
-			} else if (_is_black_(brother->_left)) {
-				brother->_right->_is_black = true;
-				brother->_is_black         = false;
-				_rotate_left_(brother);
-				brother = ptr->_parent->_left;
-			}
-			if (_is_red_(brother->_left)) {
-				brother->_is_black        = ptr->_parent->_is_black;
-				ptr->_parent->_is_black   = true;
-				brother->_left->_is_black = true;
-				_rotate_right_(ptr->_parent);
-				ptr = _root();
-			}
+			_remove_fixup_right(ptr);
 		}
 	}
 	ptr->_is_black = true;
+}
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_remove_fixup_left(node_ptr& ptr)
+{
+	node_ptr brother = ptr->_parent->_right;
+	if (_is_red_(brother)) {
+		brother->_is_black      = true;
+		ptr->_parent->_is_black = false;
+		_rotate_left_(ptr->_parent);
+		brother = ptr->_parent->_right;
+	}
+	if (_is_black_(brother->_left) && _is_black_(brother->_right)) {
+		brother->_is_black = false;
+		ptr                = ptr->_parent;
+	} else if (_is_black_(brother->_right)) {
+		brother->_left->_is_black = true;
+		brother->_is_black        = false;
+		_rotate_right_(brother);
+		brother = ptr->_parent->_right;
+	}
+	if (_is_red_(brother->_right)) {
+		brother->_is_black         = ptr->_parent->_is_black;
+		ptr->_parent->_is_black    = true;
+		brother->_right->_is_black = true;
+		_rotate_left_(ptr->_parent);
+		ptr = _root();
+	}
+}
+
+template <class T, class Comp, class Allocator>
+void _rbtree<T, Comp, Allocator>::_remove_fixup_right(node_ptr& ptr)
+{
+	node_ptr brother = ptr->_parent->_left;
+	if (_is_red_(brother)) {
+		brother->_is_black      = true;
+		ptr->_parent->_is_black = false;
+		_rotate_left_(ptr->_parent);
+		brother = ptr->_parent->_left;
+	}
+	if (_is_black_(brother->_right) && _is_black_(brother->_left)) {
+		brother->_is_black = false;
+		ptr                = ptr->_parent;
+	} else if (_is_black_(brother->_left)) {
+		brother->_right->_is_black = true;
+		brother->_is_black         = false;
+		_rotate_left_(brother);
+		brother = ptr->_parent->_left;
+	}
+	if (_is_red_(brother->_left)) {
+		brother->_is_black        = ptr->_parent->_is_black;
+		ptr->_parent->_is_black   = true;
+		brother->_left->_is_black = true;
+		_rotate_right_(ptr->_parent);
+		ptr = _root();
+	}
 }
 
 /* -------------------------------------------------------------------------- */

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -233,9 +233,10 @@ class _rbtree
 	typedef std::allocator_traits<node_allocator>                 node_traits;
 
   private:
-	node_ptr       _nil;
-	node_ptr       _begin;
-	node_ptr       _end;
+	node_ptr _nil;
+	node_ptr _begin;
+	node_ptr _end;
+
 	value_compare  _comp;
 	node_allocator _alloc;
 	size_type      _size;
@@ -246,14 +247,6 @@ class _rbtree
 	_rbtree(_rbtree const& other);
 	_rbtree&       operator=(_rbtree const& other);
 	allocator_type get_allocator() const { return allocator_type(_alloc); }
-
-	template <class _Key>
-	iterator _find(const _Key& value) const;
-	iterator erase(iterator pos);
-	void     erase(iterator first, iterator last);
-	template <class _Key>
-	size_type erase(const _Key& value);
-	void      _display(std::string func_name = "", int line = -1) const;
 
 	/* ------------------------------ Iterators ----------------------------- */
 	iterator       begin() { return iterator(_begin, _nil); }
@@ -271,12 +264,18 @@ class _rbtree
 	}
 
 	/* ------------------------------ Modifiers ----------------------------- */
-	void                     clear();
+	void clear();
+	// insert
 	ft::pair<iterator, bool> _insert(const value_type& value);
 	iterator                 _insert(iterator hint, const value_type& value);
-	node_ptr                 _insert_unique(const value_type& value, node_ptr parent);
 	template <class InputIt>
 	void _insert(InputIt first, InputIt last);
+	// erase
+	iterator erase(iterator pos);
+	void     erase(iterator first, iterator last);
+	template <class _Key>
+	size_type erase(const _Key& value);
+	// swap
 	void swap(_rbtree& other);
 
 	/* ------------------------------- Lookup ------------------------------- */
@@ -303,11 +302,8 @@ class _rbtree
 
   private:
 	node_ptr _root() const;
-	node_ptr _init_tree_node_(const value_type& value);
-	void     _insert_update(const node_ptr new_);
-	node_ptr _find_insert_position(const value_type& value, node_ptr hint = NULL);
 	void     _set_root(const node_ptr ptr);
-	void     _remove(node_ptr ptr);
+	node_ptr _init_tree_node_(const value_type& value);
 
 	void _destroy_recursive(node_ptr ptr);
 	void _destroy_one(node_ptr ptr);
@@ -316,10 +312,17 @@ class _rbtree
 	void _transplant_(node_ptr old_ptr, node_ptr new_ptr);
 	void _rotate_left_(node_ptr ptr);
 	void _rotate_right_(node_ptr ptr);
-	void _insert_fixup_(node_ptr ptr);
-	void _remove_fixup_(node_ptr ptr);
+
+	node_ptr _find_insert_position(const value_type& value, node_ptr hint = NULL);
+	node_ptr _insert_unique(const value_type& value, node_ptr parent);
+	void     _insert_fixup_(node_ptr ptr);
+	void     _insert_update(const node_ptr new_);
+	void     _remove(node_ptr ptr);
+	void     _remove_fixup_(node_ptr ptr);
 
 	/* ------------------------------- Lookup ------------------------------- */
+	template <class _Key>
+	iterator _find(const _Key& value) const;
 	template <class _Key>
 	pair<iterator, iterator> __equal_range_unique(const _Key& key);
 	template <class _Key>
@@ -330,6 +333,7 @@ class _rbtree
 	node_ptr __upper_bound(const key_type& key) const;
 
 	/* -------------------------------- debug ------------------------------- */
+	void        _display(std::string func_name = "", int line = -1) const;
 	int         _check_tree_recursive_(node_ptr ptr, int black_count, int& invalid) const;
 	void        _check_tree_validity_() const;
 	std::string _node_to_dir_(const node_ptr& value, std::string dirprefix, bool is_right) const;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -574,10 +574,25 @@ template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::node_pointer
 _rbtree<T, Comp, Allocator>::_find_insert_position(const value_type& value, node_pointer hint)
 {
-	node_pointer prev = _end;
+	node_pointer prev    = _end;
+	node_pointer current = _root();
 
-	if (hint) {}
-	for (node_pointer current = _root(); current != _nil;) {
+	if (hint && hint != _end) {
+		if (_comp(value, hint->_value) && hint->_left == _nil) {
+			iterator prev = iterator(hint, _nil);
+			// prev < value < hint
+			if (prev == begin() || _comp(*--prev, value)) {
+				return hint;
+			}
+		} else if (hint->_right == _nil) {
+			iterator next = iterator(hint, _nil);
+			// hint < value < next
+			if (next == end() || _comp(value, *++next)) {
+				return hint;
+			}
+		}
+	}
+	for (; current != _nil;) {
 		prev = current;
 		if (_comp(value, current->_value)) {
 			current = current->_left;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -24,12 +24,14 @@ class _tree_node
 	T           _value;
 	bool        _is_black;
 
-	_tree_node() : _parent(NULL), _right(NULL), _left(NULL), _is_black(false){};
+	_tree_node() : _parent(NULL), _right(NULL), _left(NULL), _is_black(false) {}
 	_tree_node(const T& value) :
-	    _parent(NULL), _right(NULL), _left(NULL), _value(value), _is_black(false){};
+	    _parent(NULL), _right(NULL), _left(NULL), _value(value), _is_black(false)
+	{}
 	_tree_node(_tree_node const& other) :
 	    _parent(other._parent), _right(other._right), _left(other._left), _value(other._value),
-	    _is_black(other._is_black){};
+	    _is_black(other._is_black)
+	{}
 	_tree_node& operator=(_tree_node const& other)
 	{
 		if (*this != other) {
@@ -40,7 +42,7 @@ class _tree_node
 			_is_black = other._is_black;
 		}
 		return *this;
-	};
+	}
 };
 
 namespace {
@@ -261,7 +263,7 @@ class _rbtree
 
 	/* ------------------------------ Capacity ------------------------------ */
 	bool      empty() const { return _root() == _nil; }
-	size_type size() const { return _size; };
+	size_type size() const { return _size; }
 	size_type max_size() const
 	{
 		return std::min<size_type>(
@@ -278,11 +280,11 @@ class _rbtree
 	void swap(_rbtree& other);
 
 	/* ------------------------------- Lookup ------------------------------- */
-	iterator       find(const key_type& key) { return iterator(__find_equal(key), _nil); };
+	iterator       find(const key_type& key) { return iterator(__find_equal(key), _nil); }
 	const_iterator find(const key_type& key) const
 	{
 		return const_iterator(__find_equal(key), _nil);
-	};
+	}
 	pair<iterator, iterator> equal_range(const key_type& key) { return __equal_range_unique(key); }
 	pair<const_iterator, const_iterator> equal_range(const key_type& key) const
 	{

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -248,13 +248,13 @@ class _rbtree
 	_rbtree&       operator=(_rbtree const& other);
 	allocator_type get_allocator() const { return allocator_type(_alloc); }
 
-	/* ------------------------------ Iterators ----------------------------- */
+	// ------------------------------ Iterators ----------------------------- //
 	iterator       begin() { return iterator(_begin, _nil); }
 	const_iterator begin() const { return const_iterator(_begin, _nil); }
 	iterator       end() { return iterator(_end, _nil); }
 	const_iterator end() const { return const_iterator(_end, _nil); }
 
-	/* ------------------------------ Capacity ------------------------------ */
+	// ------------------------------ Capacity ------------------------------ //
 	bool      empty() const { return _root() == _nil; }
 	size_type size() const { return _size; }
 	size_type max_size() const
@@ -263,7 +263,7 @@ class _rbtree
 		    node_traits::max_size(node_allocator()), std::numeric_limits<difference_type>::max());
 	}
 
-	/* ------------------------------ Modifiers ----------------------------- */
+	// ------------------------------ Modifiers ----------------------------- //
 	void clear();
 	// insert
 	ft::pair<iterator, bool> _insert(const value_type& value);
@@ -278,7 +278,7 @@ class _rbtree
 	// swap
 	void swap(_rbtree& other);
 
-	/* ------------------------------- Lookup ------------------------------- */
+	// ------------------------------- Lookup ------------------------------- //
 	iterator       find(const key_type& key) { return iterator(__find_equal(key), _nil); }
 	const_iterator find(const key_type& key) const
 	{
@@ -308,7 +308,7 @@ class _rbtree
 	void _destroy_recursive(node_ptr ptr);
 	void _destroy_one(node_ptr ptr);
 
-	/* ----------------------------- algorithms ----------------------------- */
+	// ----------------------------- algorithms ----------------------------- //
 	void _transplant_(node_ptr old_ptr, node_ptr new_ptr);
 	void _rotate_left_(node_ptr ptr);
 	void _rotate_right_(node_ptr ptr);
@@ -320,7 +320,7 @@ class _rbtree
 	void     _remove(node_ptr ptr);
 	void     _remove_fixup_(node_ptr ptr);
 
-	/* ------------------------------- Lookup ------------------------------- */
+	// ------------------------------- Lookup ------------------------------- //
 	template <class _Key>
 	iterator _find(const _Key& value) const;
 	template <class _Key>
@@ -332,7 +332,7 @@ class _rbtree
 	node_ptr __lower_bound(const key_type& key) const;
 	node_ptr __upper_bound(const key_type& key) const;
 
-	/* -------------------------------- debug ------------------------------- */
+	// -------------------------------- debug ------------------------------- //
 	void        _display(std::string func_name = "", int line = -1) const;
 	int         _check_tree_recursive_(node_ptr ptr, int black_count, int& invalid) const;
 	void        _check_tree_validity_() const;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -372,8 +372,7 @@ _rbtree<T, Comp, Allocator>::_rbtree(_rbtree const& other) :
 	_nil->_left     = _nil;
 	_nil->_right    = _nil;
 
-	_end = _alloc.allocate(1);
-	_alloc.construct(_end, *other._end);
+	_end   = _init_tree_node_(T());
 	_begin = _end;
 	_insert(other.begin(), other.end());
 }
@@ -577,8 +576,7 @@ _rbtree<T, Comp, Allocator>::_find_insert_position(const value_type& value, node
 {
 	node_pointer prev = _end;
 
-
-  if (hint) {}
+	if (hint) {}
 	for (node_pointer current = _root(); current != _nil;) {
 		prev = current;
 		if (_comp(value, current->_value)) {

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -264,10 +264,10 @@ class _rbtree
 	// ------------------------------ Modifiers ----------------------------- //
 	void clear();
 	// insert
-	ft::pair<iterator, bool> _insert(const value_type& value);
-	iterator                 _insert(iterator hint, const value_type& value);
+	ft::pair<iterator, bool> insert(const value_type& value);
+	iterator                 insert(iterator hint, const value_type& value);
 	template <class InputIt>
-	void _insert(InputIt first, InputIt last);
+	void insert(InputIt first, InputIt last);
 	// erase
 	iterator erase(iterator pos);
 	void     erase(iterator first, iterator last);
@@ -380,7 +380,7 @@ _rbtree<T, Comp, Allocator>::_rbtree(_rbtree const& other) :
 
 	_end   = _init_tree_node_(T());
 	_begin = _end;
-	_insert(other.begin(), other.end());
+	insert(other.begin(), other.end());
 }
 
 template <class T, class Comp, class Allocator>
@@ -408,7 +408,7 @@ void _rbtree<T, Comp, Allocator>::clear()
 /* --------------------------------- Insert --------------------------------- */
 template <class T, class Comp, class Allocator>
 typename ft::pair<typename _rbtree<T, Comp, Allocator>::iterator, bool>
-_rbtree<T, Comp, Allocator>::_insert(const value_type& value)
+_rbtree<T, Comp, Allocator>::insert(const value_type& value)
 {
 	node_ptr ptr = _find_insert_position(value);
 	if (ptr != _end && !_comp(ptr->_value, value) && !_comp(value, ptr->_value)) {
@@ -419,7 +419,7 @@ _rbtree<T, Comp, Allocator>::_insert(const value_type& value)
 
 template <class T, class Comp, class Allocator>
 typename _rbtree<T, Comp, Allocator>::iterator
-_rbtree<T, Comp, Allocator>::_insert(iterator hint, const value_type& value)
+_rbtree<T, Comp, Allocator>::insert(iterator hint, const value_type& value)
 {
 	node_ptr ptr = _find_insert_position(value, hint.base());
 	if (ptr != _end && !_comp(ptr->_value, value) && !_comp(value, ptr->_value)) {
@@ -430,10 +430,10 @@ _rbtree<T, Comp, Allocator>::_insert(iterator hint, const value_type& value)
 
 template <class T, class Comp, class Allocator>
 template <class InputIt>
-void _rbtree<T, Comp, Allocator>::_insert(InputIt first, InputIt last)
+void _rbtree<T, Comp, Allocator>::insert(InputIt first, InputIt last)
 {
 	for (; first != last; ++first) {
-		_insert(*first);
+		insert(*first);
 	}
 }
 

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -469,7 +469,8 @@ _rbtree<T, Comp, Allocator>::erase(const _Key& value)
 	}
 	if (begin() == ite) {
 		iterator next(ite);
-		_begin = ++next.base();
+		++next;
+		_begin = next.base();
 	}
 	--_size;
 	_remove(ite.base());

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -381,7 +381,6 @@ _rbtree<T, Comp, Allocator>::_insert(const value_type& value)
 		parent->_right = new_;
 	}
 	new_->_parent = parent;
-	_display(__FUNCTION__, __LINE__);
 	_insert_fixup_(new_);
 	_insert_update(new_);
 	return ft::make_pair(iterator(new_, _nil), true);
@@ -605,13 +604,11 @@ void _rbtree<T, Comp, Allocator>::_rotate_left_(const node_pointer ptr)
 	}
 	child->_left = ptr;
 	ptr->_parent = child;
-	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_pointer ptr)
 {
-	_display(__FUNCTION__, __LINE__);
 	node_pointer child = ptr->_left;
 	ptr->_left         = child->_right;
 	if (ptr->_right != _nil) {
@@ -628,7 +625,6 @@ void _rbtree<T, Comp, Allocator>::_rotate_right_(const node_pointer ptr)
 	}
 	child->_right = ptr;
 	ptr->_parent  = child;
-	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>
@@ -673,7 +669,6 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup_(node_pointer ptr)
 		}
 	}
 	_root->_is_black = true;
-	_display(__FUNCTION__, __LINE__);
 }
 
 template <class T, class Comp, class Allocator>

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -226,8 +226,8 @@ class _rbtree
 	typedef _rbtree_iterator<value_type, node_type>       iterator;
 	typedef _rbtree_iterator<const value_type, node_type> const_iterator;
 
-	typedef std::size_t    size_type;
-	typedef std::ptrdiff_t difference_type;
+	typedef size_t    size_type;
+	typedef ptrdiff_t difference_type;
 
 	typedef typename Allocator::template rebind<node_type>::other node_allocator;
 	typedef std::allocator_traits<node_allocator>                 node_traits;

--- a/includes/rbtree.hpp
+++ b/includes/rbtree.hpp
@@ -722,54 +722,54 @@ void _rbtree<T, Comp, Allocator>::_insert_fixup_(node_pointer ptr)
 template <class T, class Comp, class Allocator>
 void _rbtree<T, Comp, Allocator>::_remove_fixup_(const node_pointer ptr)
 {
-	node_pointer cousin;
+	node_pointer brother;
 
 	while (ptr != _root && _is_black_(ptr)) {
 		if (_is_left_child_(ptr)) {
-			cousin = ptr->_parent->_right;
-			if (_is_red_(cousin)) {
-				cousin->_is_black       = true;
+			brother = ptr->_parent->_right;
+			if (_is_red_(brother)) {
+				brother->_is_black      = true;
 				ptr->_parent->_is_black = false;
 				_rotate_left_(ptr->_parent);
-				cousin = ptr->_parent->_right;
+				brother = ptr->_parent->_right;
 			}
-			if (_is_black_(cousin->_left) && _is_black_(cousin->_right)) {
-				cousin->_is_black = false;
-				ptr               = ptr->_parent;
-			} else if (_is_black_(cousin->_right)) {
-				cousin->_left->_is_black = true;
-				cousin->_is_black        = false;
-				_rotate_right_(cousin);
-				cousin = ptr->_parent->_right;
+			if (_is_black_(brother->_left) && _is_black_(brother->_right)) {
+				brother->_is_black = false;
+				ptr                = ptr->_parent;
+			} else if (_is_black_(brother->_right)) {
+				brother->_left->_is_black = true;
+				brother->_is_black        = false;
+				_rotate_right_(brother);
+				brother = ptr->_parent->_right;
 			}
-			if (_is_red_(cousin->_right)) {
-				cousin->_is_black         = ptr->_parent->_is_black;
-				ptr->_parent->_is_black   = true;
-				cousin->_right->_is_black = true;
+			if (_is_red_(brother->_right)) {
+				brother->_is_black         = ptr->_parent->_is_black;
+				ptr->_parent->_is_black    = true;
+				brother->_right->_is_black = true;
 				_rotate_left_(ptr->_parent);
 				ptr = _root;
 			}
 		} else {
-			cousin = ptr->_parent->_left;
-			if (_is_red_(cousin)) {
-				cousin->_is_black       = true;
+			brother = ptr->_parent->_left;
+			if (_is_red_(brother)) {
+				brother->_is_black      = true;
 				ptr->_parent->_is_black = false;
 				_rotate_left_(ptr->_parent);
-				cousin = ptr->_parent->_left;
+				brother = ptr->_parent->_left;
 			}
-			if (_is_black_(cousin->_right) && _is_black_(cousin->_left)) {
-				cousin->_is_black = false;
-				ptr               = ptr->_parent;
-			} else if (_is_black_(cousin->_left)) {
-				cousin->_right->_is_black = true;
-				cousin->_is_black         = false;
-				_rotate_left_(cousin);
-				cousin = ptr->_parent->_left;
+			if (_is_black_(brother->_right) && _is_black_(brother->_left)) {
+				brother->_is_black = false;
+				ptr                = ptr->_parent;
+			} else if (_is_black_(brother->_left)) {
+				brother->_right->_is_black = true;
+				brother->_is_black         = false;
+				_rotate_left_(brother);
+				brother = ptr->_parent->_left;
 			}
-			if (_is_red_(cousin->_left)) {
-				cousin->_is_black        = ptr->_parent->_is_black;
-				ptr->_parent->_is_black  = true;
-				cousin->_left->_is_black = true;
+			if (_is_red_(brother->_left)) {
+				brother->_is_black        = ptr->_parent->_is_black;
+				ptr->_parent->_is_black   = true;
+				brother->_left->_is_black = true;
 				_rotate_right_(ptr->_parent);
 				ptr = _root;
 			}

--- a/test_srcs/map/MapTest_NonMemberFunctions.cpp
+++ b/test_srcs/map/MapTest_NonMemberFunctions.cpp
@@ -415,6 +415,8 @@ void _map_std_swap_basic()
 	ft::map<int, int> ft_b   = _set_map(size_b, true);
 
 	ft::swap(ft_a, ft_b);
+	UnitTester::assert_(ft_a.size() == size_b);
+	UnitTester::assert_(ft_b.size() == size_a);
 }
 
 void _map_std_swap_compare()

--- a/test_srcs/map/MapTest_NonMemberFunctions.cpp
+++ b/test_srcs/map/MapTest_NonMemberFunctions.cpp
@@ -414,10 +414,7 @@ void _map_std_swap_basic()
 	ft::map<int, int> ft_a   = _set_map(size_a, false);
 	ft::map<int, int> ft_b   = _set_map(size_b, true);
 
-	std::swap(ft_a, ft_b);
-	for (size_t i = 0; i < size_b; ++i) {
-		ft_a[i] = i;
-	}
+	ft::swap(ft_a, ft_b);
 }
 
 void _map_std_swap_compare()
@@ -431,7 +428,7 @@ void _map_std_swap_compare()
 	std::map<int, std::string> std_b;
 	_set_compare_maps(ft_b, std_b);
 
-	std::swap(ft_a, ft_b);
+	ft::swap(ft_a, ft_b);
 	std::swap(std_a, std_b);
 	_compare_maps(ft_a, std_a);
 	_compare_maps(ft_b, std_b);


### PR DESCRIPTION
- fix: compile error (erase2.cpp)
- delete: call for _display()
- update: delete _root and create _root()
- fix: tester std::swap to ft::swap
- fix: tester swap basic
- fix: dependency on iterator_traits
- refactor: rename cousin -> brother
- fix #63: set right nil node in end node
- feat: resolve #62; use hint
- refactor: delete trailing commas
- refactor: rename node_pointer -> node_ptr
- refactor: delete std
- refactor: move function declarations around
- style: spacing and comments style
- refactor: _tree_node to struct
- refactor: iterator parent class
- refactor: reorder functions
- refactor: rename _insert -> insert
- delete: _find()
- refactor: rename ~fixup -> ~fixup_
- refactor: separate remove_fixup to right and left
- refactor: separate insert_fixup to right and left
